### PR TITLE
Require stricter OID matching when performing FHIR CS URL lookup

### DIFF
--- a/src/main/java/gov/cms/madie/terminology/mapper/VsacToFhirValueSetMapper.java
+++ b/src/main/java/gov/cms/madie/terminology/mapper/VsacToFhirValueSetMapper.java
@@ -170,7 +170,10 @@ public class VsacToFhirValueSetMapper {
 
     if (!StringUtils.isBlank(oid)) {
       Optional<CodeSystemEntry> codeSystemEntry =
-          codeSystemEntries.stream().filter(cse -> cse.getOid().contains(oid)).findFirst();
+          codeSystemEntries.stream().filter(cse -> cse.getOid()
+              .replace("urn:oid:","")
+              .equals(oid))
+              .findFirst();
       if (codeSystemEntry.isPresent()) {
         return codeSystemEntry.get().getUrl();
       }

--- a/src/test/java/gov/cms/madie/terminology/mapper/VsacToFhirValueSetMapperTest.java
+++ b/src/test/java/gov/cms/madie/terminology/mapper/VsacToFhirValueSetMapperTest.java
@@ -292,4 +292,23 @@ public class VsacToFhirValueSetMapperTest {
 
     assertEquals(url, TEST);
   }
+
+  @Test
+  public void testGetUrlByOidWithSimilarMatches() {
+    CodeSystemEntry substringOid = CodeSystemEntry.builder()
+        .name(TEST)
+        .oid(TEST_OID)
+        .url(TEST_URL)
+        .build();
+    CodeSystemEntry fullOid = CodeSystemEntry.builder()
+        .oid(TEST_OID + "1")
+        .url(TEST_URL + "/1")
+        .name(TEST + "1")
+        .build();
+    List<CodeSystemEntry> codeSystemList = List.of(fullOid, substringOid);
+    when(mappingService.getCodeSystemEntries()).thenReturn(codeSystemList);
+
+    String url = mapper.getUrlByOid(TEST_OID);
+    assertEquals(TEST_URL, url);
+  }
 }


### PR DESCRIPTION
## Terminology Service PR

### Summary

Code system OIDs can be very similar. For instance:

2.16.840.1.113883.6.12 (CPT)
2.16.840.1.113883.6.1  (LOINC)

Hence, the search pattern must match exactly. Modified the filter criteria to be equivalent on OID value excluding the prefix.

The 'urn:oid:' prefix, when present, is being removed just in case the prefix is ever altered or Code Systems are added to VSAC that have alternative prefixes.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
