### PR TITLE
MAT-7310: Append includeDraft=true to FHIR Term requests when Latest is selected (manifest is null).

### DIFF
--- a/src/main/java/gov/cms/madie/terminology/util/TerminologyServiceUtil.java
+++ b/src/main/java/gov/cms/madie/terminology/util/TerminologyServiceUtil.java
@@ -124,6 +124,8 @@ public class TerminologyServiceUtil {
     } else if (manifestExpansion != null
         && StringUtils.isNotBlank(manifestExpansion.getFullUrl())) {
       params.put("manifest", List.of(manifestExpansion.getFullUrl()));
+    } else if (StringUtils.isNotBlank(includeDraft)) {
+      params.put("includeDraft", List.of("true"));
     }
     return UriComponentsBuilder.fromPath(expandValueSetUri).queryParams(params).build().toUri();
   }

--- a/src/test/java/gov/cms/madie/terminology/webclient/FhirTerminologyServiceWebClientTest.java
+++ b/src/test/java/gov/cms/madie/terminology/webclient/FhirTerminologyServiceWebClientTest.java
@@ -100,6 +100,23 @@ class FhirTerminologyServiceWebClientTest {
   }
 
   @Test
+  void getDraftValueSetResourceSuccessfully_when_noCustomSearchCriteriaIsProvided()
+      throws InterruptedException {
+    mockBackEnd.enqueue(
+        new MockResponse()
+            .setResponseCode(200)
+            .setBody(MOCK_RESPONSE_STRING)
+            .addHeader("Content-Type", "application/fhir+json"));
+    String actualResponse =
+        fhirTerminologyServiceWebClient.getValueSetResource(
+            MOCK_API_KEY, testValueSetParams, null, "yes", new ManifestExpansion());
+    assertNotNull(actualResponse);
+    assertEquals(MOCK_RESPONSE_STRING, actualResponse);
+    RecordedRequest recordedRequest = mockBackEnd.takeRequest();
+    assertEquals("/ValueSet/test-vs-id/$expand?includeDraft=true", recordedRequest.getPath());
+  }
+
+  @Test
   void getValueSetResourceSuccessfully_when_manifestExpansionIsProvided()
       throws InterruptedException {
     mockBackEnd.enqueue(


### PR DESCRIPTION
## Terminology Service PR

Jira Ticket: [MAT-7310](https://jira.cms.gov/browse/MAT-7310)
(Optional) Related Tickets:

### Summary

Match our FHIR Term "Latest" calls with SVS "Latest" calls by appending `includeDraft=true` to "Latest" FHIR Term requests.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
