### PR TITLE
MAT-7373: Include the FHIR Bundle returned from VSAC FHIR Term Service in the Value Set search response

### DIFF
--- a/src/main/java/gov/cms/madie/terminology/controller/VsacFhirTerminologyController.java
+++ b/src/main/java/gov/cms/madie/terminology/controller/VsacFhirTerminologyController.java
@@ -3,7 +3,7 @@ package gov.cms.madie.terminology.controller;
 import gov.cms.madie.models.measure.ManifestExpansion;
 import gov.cms.madie.terminology.dto.Code;
 import gov.cms.madie.terminology.dto.QdmValueSet;
-import gov.cms.madie.terminology.dto.ValueSetForSearch;
+import gov.cms.madie.terminology.dto.ValueSetSearchResult;
 import gov.cms.madie.terminology.dto.ValueSetsSearchCriteria;
 import gov.cms.madie.terminology.models.CodeSystem;
 import gov.cms.madie.terminology.models.UmlsUser;
@@ -72,7 +72,7 @@ public class VsacFhirTerminologyController {
 
   @GetMapping(path = "/search-value-sets", produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseBody
-  public ResponseEntity<List<ValueSetForSearch>> searchValueSets(
+  public ResponseEntity<ValueSetSearchResult> searchValueSets(
       Principal principal, @RequestParam Map<String, String> queryParams) {
     final String username = principal.getName();
     UmlsUser umlsUser = vsacService.verifyUmlsAccess(username);

--- a/src/main/java/gov/cms/madie/terminology/dto/ValueSetSearchResult.java
+++ b/src/main/java/gov/cms/madie/terminology/dto/ValueSetSearchResult.java
@@ -1,0 +1,16 @@
+package gov.cms.madie.terminology.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class ValueSetSearchResult {
+  List<ValueSetForSearch> valueSets;
+  // Returning bundle as String because the FHIR Parser generates
+  // a typed Bundle object that is excessively huge when serialized
+  // since it initializes all values and arrays to null/empty array.
+  String resultBundle;
+}

--- a/src/main/java/gov/cms/madie/terminology/service/FhirTerminologyService.java
+++ b/src/main/java/gov/cms/madie/terminology/service/FhirTerminologyService.java
@@ -122,7 +122,7 @@ public class FhirTerminologyService {
     return List.of();
   }
 
-  public List<ValueSetForSearch> searchValueSets(String apiKey, Map<String, String> queryParams) {
+  public ValueSetSearchResult searchValueSets(String apiKey, Map<String, String> queryParams) {
     IParser parser = fhirContext.newJsonParser();
     String responseString = fhirTerminologyServiceWebClient.searchValueSets(apiKey, queryParams);
     Bundle bundle = parser.parseResource(Bundle.class, responseString);
@@ -177,8 +177,7 @@ public class FhirTerminologyService {
               }
               log.info("valueSetList {}", valueSetList);
             });
-
-    return valueSetList;
+    return ValueSetSearchResult.builder().valueSets(valueSetList).resultBundle(responseString).build();
   }
 
   public List<CodeSystem> getAllCodeSystems() {

--- a/src/test/java/gov/cms/madie/terminology/controller/VsacFhirTerminologyControllerTest.java
+++ b/src/test/java/gov/cms/madie/terminology/controller/VsacFhirTerminologyControllerTest.java
@@ -285,11 +285,11 @@ class VsacFhirTerminologyControllerTest {
     Principal principal = mock(Principal.class);
     when(principal.getName()).thenReturn(TEST_USER);
     when(vsacService.verifyUmlsAccess(anyString())).thenReturn(umlsUser);
-    when(fhirTerminologyService.searchValueSets(any(), any())).thenReturn(mockValueSets);
+    when(fhirTerminologyService.searchValueSets(any(), any())).thenReturn(ValueSetSearchResult.builder().valueSets(mockValueSets).build());
     Map<String, String> queryParams = new HashMap<>();
     queryParams.put("param1", "value1");
     queryParams.put("param2", "value2");
-    ResponseEntity<List<ValueSetForSearch>> response =
+    ResponseEntity<ValueSetSearchResult> response =
         vsacFhirTerminologyController.searchValueSets(principal, queryParams);
     assertEquals(response.getStatusCode(), HttpStatus.OK);
   }


### PR DESCRIPTION
## Terminology Service PR

Jira Ticket: [MAT-7373](https://jira.cms.gov/browse/MAT-7373)
(Optional) Related Tickets:

### Summary

Include the FHIR Bundle that comes back from VSAC's FHIR Terminology Service when searching for Value Sets in our search API's response. The entries of which will be displayed as value set "details" to the user when requested.

Note: The Bundle is returned as a String because the typed Bundle object is excessively huge when serialized to JSON as the FHIR Parser inits null/empty values by default.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
