### PR TITLE
MAT-7471: Disable auto-encoding on FhirTerminologyServiceWebClient

### DIFF
--- a/src/main/java/gov/cms/madie/terminology/service/FhirTerminologyService.java
+++ b/src/main/java/gov/cms/madie/terminology/service/FhirTerminologyService.java
@@ -177,7 +177,10 @@ public class FhirTerminologyService {
               }
               log.info("valueSetList {}", valueSetList);
             });
-    return ValueSetSearchResult.builder().valueSets(valueSetList).resultBundle(responseString).build();
+    return ValueSetSearchResult.builder()
+        .valueSets(valueSetList)
+        .resultBundle(responseString)
+        .build();
   }
 
   public List<CodeSystem> getAllCodeSystems() {

--- a/src/main/java/gov/cms/madie/terminology/webclient/FhirTerminologyServiceWebClient.java
+++ b/src/main/java/gov/cms/madie/terminology/webclient/FhirTerminologyServiceWebClient.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 
@@ -42,9 +43,12 @@ public class FhirTerminologyServiceWebClient {
       @Value("${client.fhir-terminology-service.code-lookups}") String codeLookupsUrl,
       @Value("${client.default_profile}") String defaultProfile,
       @Value("${client.search_value_set_endpoint}") String searchValueSetEndpoint) {
+    DefaultUriBuilderFactory uriBuilderFactory =
+        new DefaultUriBuilderFactory(fhirTerminologyServiceBaseUrl);
+    uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
     fhirTerminologyWebClient =
         WebClient.builder()
-            .baseUrl(fhirTerminologyServiceBaseUrl)
+            .uriBuilderFactory(uriBuilderFactory)
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .codecs(
                 clientCodecConfigurer -> clientCodecConfigurer.defaultCodecs().maxInMemorySize(-1))

--- a/src/test/java/gov/cms/madie/terminology/controller/VsacFhirTerminologyControllerTest.java
+++ b/src/test/java/gov/cms/madie/terminology/controller/VsacFhirTerminologyControllerTest.java
@@ -285,7 +285,8 @@ class VsacFhirTerminologyControllerTest {
     Principal principal = mock(Principal.class);
     when(principal.getName()).thenReturn(TEST_USER);
     when(vsacService.verifyUmlsAccess(anyString())).thenReturn(umlsUser);
-    when(fhirTerminologyService.searchValueSets(any(), any())).thenReturn(ValueSetSearchResult.builder().valueSets(mockValueSets).build());
+    when(fhirTerminologyService.searchValueSets(any(), any()))
+        .thenReturn(ValueSetSearchResult.builder().valueSets(mockValueSets).build());
     Map<String, String> queryParams = new HashMap<>();
     queryParams.put("param1", "value1");
     queryParams.put("param2", "value2");

--- a/src/test/java/gov/cms/madie/terminology/webclient/FhirTerminologyServiceWebClientTest.java
+++ b/src/test/java/gov/cms/madie/terminology/webclient/FhirTerminologyServiceWebClientTest.java
@@ -8,7 +8,6 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -31,7 +30,7 @@ class FhirTerminologyServiceWebClientTest {
 
   private ValueSetsSearchCriteria.ValueSetParams testValueSetParams;
 
-  @InjectMocks FhirTerminologyServiceWebClient fhirTerminologyServiceWebClient;
+  FhirTerminologyServiceWebClient fhirTerminologyServiceWebClient;
 
   @BeforeAll
   static void setUp() throws IOException {


### PR DESCRIPTION
## Terminology Service PR

Jira Ticket: [MAT-7471](https://jira.cms.gov/browse/MAT-7471)
(Optional) Related Tickets:

### Summary

Manually control when uri data is html encoded by disabling auto-encoding on `FhirTerminologyServiceWebClient`.

Our config of the `FhirTerminologyServiceWebClient` auto-encodes String uri values by way of setting the `WebClient.Builder baseUrl()`. Effectively, doing so serves as a shortcut to use the default `UriBuilderFactory`, which is configured to encode uri Strings by default. 

When a URI object is passed to the WebClient request chain, the `UriBuilderFactory` is not used. Instead, the WebClient uses the supplied URI as is. Which also means it does not use the `baseUrl` set on the WebClient since the `baseUrl` is passed down to the default `UriBuilderFactory` instance that gets bypassed when making a request with a URI object.

See: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/reactive/function/client/WebClient.Builder.html#baseUrl(java.lang.String)

See: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/util/DefaultUriBuilderFactory.html#setEncodingMode(org.springframework.web.util.DefaultUriBuilderFactory.EncodingMode)

### All Submissions
* [x] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
