### PR TITLE
MAT-7859: Guard against unexpected Value Set Status values by mapping them to UNKNOWN

### DIFF
--- a/src/main/java/gov/cms/madie/terminology/mapper/VsacToFhirValueSetMapper.java
+++ b/src/main/java/gov/cms/madie/terminology/mapper/VsacToFhirValueSetMapper.java
@@ -7,6 +7,7 @@ import gov.cms.madie.models.mapping.CodeSystemEntry;
 import gov.cms.madie.terminology.service.MappingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.Identifier;
@@ -55,14 +56,21 @@ public class VsacToFhirValueSetMapper {
     fhirValueSet.setName(vsacDescribedValueSet.getDisplayName());
     fhirValueSet.setTitle(vsacDescribedValueSet.getDisplayName());
     fhirValueSet.setVersion(vsacDescribedValueSet.getVersion());
-    fhirValueSet.setStatus(
-        PublicationStatus.fromCode(vsacDescribedValueSet.getStatus().toLowerCase()));
+    fhirValueSet.setStatus(mapVsacValueSetStatusToFhir(vsacDescribedValueSet.getStatus()));
     fhirValueSet.setDate(vsacDescribedValueSet.getRevisionDate().toGregorianCalendar().getTime());
     fhirValueSet.setPublisher(vsacDescribedValueSet.getSource());
     // ??
     fhirValueSet.setDescription(vsacDescribedValueSet.getDefinition());
     fhirValueSet.setPurpose(vsacDescribedValueSet.getPurpose());
     return fhirValueSet;
+  }
+
+  private PublicationStatus mapVsacValueSetStatusToFhir(String vsacStatus) {
+    try {
+      return PublicationStatus.fromCode(vsacStatus.toLowerCase());
+    } catch (FHIRException | NullPointerException e) {
+      return PublicationStatus.UNKNOWN;
+    }
   }
 
   protected void addFhirValueSetComposeComponent(

--- a/src/test/java/gov/cms/madie/terminology/mapper/VsacToFhirValueSetMapperTest.java
+++ b/src/test/java/gov/cms/madie/terminology/mapper/VsacToFhirValueSetMapperTest.java
@@ -13,6 +13,7 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.hl7.fhir.r4.model.ValueSet.ConceptReferenceComponent;
 import org.hl7.fhir.r4.model.ValueSet.ValueSetComposeComponent;
@@ -141,6 +142,14 @@ public class VsacToFhirValueSetMapperTest {
     assertEquals(vs.getDescription(), TEST);
     assertEquals(vs.getPurpose(), TEST);
     assertEquals(vs.getDate(), today);
+  }
+
+  @Test
+  public void testMapMainAttributesUnknownStatus() {
+    ValueSet vs = new ValueSet();
+    describedValueSet.setStatus("Not Maintained");
+    vs = mapper.setFhirMainAttributes(vs, describedValueSet, TEST);
+    assertEquals(Enumerations.PublicationStatus.UNKNOWN.getDisplay(), vs.getStatus().getDisplay());
   }
 
   @Test


### PR DESCRIPTION
## Terminology Service PR

Jira Ticket: [MAT-7859](https://jira.cms.gov/browse/MAT-7859)
(Optional) Related Tickets:

### Summary

When mapping SVS Value Sets to FHIR, map unknown Status values to FHIRPublication.UNKNOWN by handling the Exception thrown by HAPI's internal mapper.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
