### PR TITLE
[MAT-8080] Exclude HCPCS Level 1 when caching Code Systems

### DIFF
--- a/src/main/java/gov/cms/madie/terminology/service/FhirTerminologyService.java
+++ b/src/main/java/gov/cms/madie/terminology/service/FhirTerminologyService.java
@@ -371,13 +371,6 @@ public class FhirTerminologyService {
         .forEach(
             entry -> {
               var codeSystem = (org.hl7.fhir.r4.model.CodeSystem) entry.getResource();
-              String codeSystemValue = "";
-              for (Identifier identifier : codeSystem.getIdentifier()) {
-                if (identifier.getValue() != null && !identifier.getValue().isEmpty()) {
-                  codeSystemValue = identifier.getValue();
-                  break;
-                }
-              }
               codeSystemsPage.add(
                   CodeSystem.builder()
                       .id(codeSystem.getTitle() + codeSystem.getVersion())
@@ -386,7 +379,7 @@ public class FhirTerminologyService {
                       .name(codeSystem.getName())
                       .version(codeSystem.getVersion())
                       .versionId(codeSystem.getMeta().getVersionId())
-                      .oid(codeSystemValue)
+                      .oid(parseOidFromIdentifier(codeSystem.getIdentifier()))
                       .lastUpdated(Instant.now())
                       .lastUpdatedUpstream(codeSystem.getMeta().getLastUpdated())
                       .build());
@@ -406,6 +399,24 @@ public class FhirTerminologyService {
                 umlsUser, Integer.parseInt(newOffset), Integer.parseInt(newCount), allCodeSystems);
           }
         });
+  }
+
+  private String parseOidFromIdentifier(List<Identifier> identifiers) {
+    for (Identifier identifier : identifiers) {
+      if (identifier.getValue() != null && !identifier.getValue().isEmpty()) {
+        // HCPCS contains two OIDs, which VSAC returns as comma delimited String.
+        // MADiE is only concerned with the Level 2 OID ending in .285 as it
+        // CMS's custom codes. Level 1 is a duplicate of CPT, and
+        // users should be utilizing CPT directly.
+        if (StringUtils.equalsIgnoreCase(
+            StringUtils.deleteWhitespace(identifier.getValue()),
+            "urn:oid:2.16.840.1.113883.6.14,2.16.840.1.113883.6.285")) {
+          return "urn:oid:2.16.840.1.113883.6.285";
+        }
+        return identifier.getValue();
+      }
+    }
+    return "";
   }
 
   // one to call only, one to mutate and build


### PR DESCRIPTION
## Terminology Service PR

Jira Ticket: [MAT-8080](https://jira.cms.gov/browse/MAT-8080)
(Optional) Related Tickets:

### Summary

For reasons unknown, VSAC returns the HCPCS OIDs as a single, comma delimited, String. MADiE assumes a single OID per Code System. The double OID string saves to mongo without issue, but causes downstream issues when read by consuming services.

Exclude the HCPCS Level 1 OID since Level 1 is a duplicate of CPT and users have received guidance to use CPT instead.

The upsert job will overwrite the current double OID entries with the single (.285) OID.

#### Resolves missing version options in UI:
![Screenshot 2025-01-07 at 3 16 46 PM](https://github.com/user-attachments/assets/674dd1da-d566-4108-8c87-07ba6e2be3d0)

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
