### PR TITLE
MAT-9672: Load mapping doc as a Resource

### DIFF
--- a/src/main/java/gov/cms/madie/terminology/config/migrations/LoadCodeSystemMappingData.java
+++ b/src/main/java/gov/cms/madie/terminology/config/migrations/LoadCodeSystemMappingData.java
@@ -13,15 +13,15 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.*;
 
 @ChangeUnit(id = "load-code-system-mapping-from-doc", order = "1", author = "madie-dev")
 @Slf4j
 public class LoadCodeSystemMappingData {
 
-  private final String CODE_SYSTEM_ENTRY_FILE_PATH = "src/main/resources/code-system-entry.json";
   private final List<CodeSystem> originalCodeSystems = new ArrayList<>();
 
   @Execution
@@ -30,6 +30,13 @@ public class LoadCodeSystemMappingData {
       CodeSystemRepository codeSystemRepository,
       ObjectMapper objectMapper,
       UpdateCodeSystemTask updateCodeSystemTask) {
+
+    // Load code-mapping-entry.json
+    List<CodeSystemEntry> codeSystemEntries = deserializeFromFile(objectMapper);
+    if (CollectionUtils.isEmpty(codeSystemEntries)) {
+      log.error("Unable to load code system mapping doc.");
+      throw new UncheckedIOException(new IOException("Unable to load code system mapping doc."));
+    }
 
     // Drop the existing codeSystem collection to allow for model changes.
     mongoTemplate.dropCollection("codeSystem");
@@ -42,12 +49,15 @@ public class LoadCodeSystemMappingData {
     // Store a copy of the original code system for potential rollback
     codeSystems.forEach(
         codeSystem -> {
-          // Duplication with Builder is sufficient since all fields in CodeSystem
-          // are either primitives or immutable (String, boolean, etc.)
-          originalCodeSystems.add(codeSystem.toBuilder().build());
+          originalCodeSystems.add(
+              codeSystem.toBuilder()
+                  .version(
+                      CodeSystem.Version.builder()
+                          .fhirVersion(codeSystem.getVersion().getFhirVersion())
+                          .vsacVersion(codeSystem.getVersion().getVsacVersion())
+                          .build())
+                  .build());
         });
-
-    List<CodeSystemEntry> codeSystemEntries = deserializeFromFile(objectMapper);
 
     for (CodeSystemEntry entry : codeSystemEntries) {
       boolean isLastestVersion = true; // First version in the list is the latest.
@@ -105,7 +115,7 @@ public class LoadCodeSystemMappingData {
   }
 
   /**
-   * Deserialize code-system-entry.json from a file path into a List of CodeSystemEntry objects.
+   * Deserialize code-system-entry.json from Resource into a List of CodeSystemEntry objects.
    *
    * @param objectMapper the ObjectMapper to use for deserialization. Exposed as a parameter for
    *     easier testing.
@@ -113,19 +123,30 @@ public class LoadCodeSystemMappingData {
    */
   private List<CodeSystemEntry> deserializeFromFile(ObjectMapper objectMapper) {
     try {
-      CodeSystemEntry[] entries =
-          objectMapper.readValue(new File(CODE_SYSTEM_ENTRY_FILE_PATH), CodeSystemEntry[].class);
+      CodeSystemEntry[] entries = objectMapper.readValue(loadMappingDoc(), CodeSystemEntry[].class);
       if (entries != null) {
         log.info(
             "Successfully deserialized {} CodeSystemEntry objects from file: {}",
             entries.length,
-            CODE_SYSTEM_ENTRY_FILE_PATH);
+            "/code-system-entry.json");
         return Arrays.asList(entries);
       }
     } catch (IOException e) {
-      log.error(
-          "Error deserializing CodeSystemEntry from file: {}", CODE_SYSTEM_ENTRY_FILE_PATH, e);
+      log.error("Error deserializing CodeSystemEntry from file: {}", "/code-system-entry.json", e);
     }
     return Collections.emptyList();
+  }
+
+  private String loadMappingDoc() {
+    try (InputStream inputStream =
+        LoadCodeSystemMappingData.class.getResourceAsStream("/code-system-entry.json")) {
+      if (inputStream == null) {
+        throw new UncheckedIOException(
+            new IOException("Unable to read resource /code-system-entry.json"));
+      }
+      return new String(inputStream.readAllBytes());
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 }

--- a/src/test/java/gov/cms/madie/terminology/config/migrations/LoadCodeSystemMappingDataTest.java
+++ b/src/test/java/gov/cms/madie/terminology/config/migrations/LoadCodeSystemMappingDataTest.java
@@ -1,5 +1,6 @@
 package gov.cms.madie.terminology.config.migrations;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.madie.models.mapping.CodeSystemEntry;
 import gov.cms.madie.terminology.models.CodeSystem;
@@ -9,15 +10,10 @@ import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -62,16 +58,15 @@ class LoadCodeSystemMappingDataTest {
                 List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").vsac("1.0.0").build()))
             .build();
 
-    doNothing().when(mongoTemplateMock).dropCollection(anyString());
-    doNothing().when(updateCodeSystemTaskMock).updateCodeSystems();
+    lenient().doNothing().when(mongoTemplateMock).dropCollection(anyString());
+    lenient().doNothing().when(updateCodeSystemTaskMock).updateCodeSystems();
   }
 
   @Test
-  void testExistingCodeSystemWithMatchingFhirAndVsacVersions() throws IOException {
-
+  void testExistingCodeSystemWithMatchingFhirAndVsacVersions() throws JsonProcessingException {
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
 
-    when(objectMapperMock.readValue(any(File.class), eq(CodeSystemEntry[].class)))
+    when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
         .thenReturn(new CodeSystemEntry[] {mappingDocEntry});
 
     migration.apply(
@@ -94,13 +89,14 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithMatchingFhirAndDifferingVsacVersions() throws IOException {
+  void testExistingCodeSystemWithMatchingFhirAndDifferingVsacVersions()
+      throws JsonProcessingException {
     mappingDocEntry.setVersions(
         List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").vsac("9.9.9").build()));
 
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
 
-    when(objectMapperMock.readValue(any(File.class), eq(CodeSystemEntry[].class)))
+    when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
         .thenReturn(new CodeSystemEntry[] {mappingDocEntry});
     migration.apply(
         mongoTemplateMock, codeSystemRepositoryMock, objectMapperMock, updateCodeSystemTaskMock);
@@ -121,7 +117,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithMultipleVersions() throws IOException {
+  void testExistingCodeSystemWithMultipleVersions() throws JsonProcessingException {
     mappingDocEntry.setVersions(
         List.of(
             // Latest first
@@ -130,7 +126,7 @@ class LoadCodeSystemMappingDataTest {
 
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
 
-    when(objectMapperMock.readValue(any(File.class), eq(CodeSystemEntry[].class)))
+    when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
         .thenReturn(new CodeSystemEntry[] {mappingDocEntry});
     migration.apply(
         mongoTemplateMock, codeSystemRepositoryMock, objectMapperMock, updateCodeSystemTaskMock);
@@ -165,12 +161,12 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithOnlyVsacVersions() throws IOException {
+  void testExistingCodeSystemWithOnlyVsacVersions() throws JsonProcessingException {
     mappingDocEntry.setVersions(List.of(CodeSystemEntry.Version.builder().vsac("9.9.9").build()));
 
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
 
-    when(objectMapperMock.readValue(any(File.class), eq(CodeSystemEntry[].class)))
+    when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
         .thenReturn(new CodeSystemEntry[] {mappingDocEntry});
     migration.apply(
         mongoTemplateMock, codeSystemRepositoryMock, objectMapperMock, updateCodeSystemTaskMock);
@@ -187,11 +183,11 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithOnlyFhirVersions() throws IOException {
+  void testExistingCodeSystemWithOnlyFhirVersions() throws JsonProcessingException {
     mappingDocEntry.setVersions(List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").build()));
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
 
-    when(objectMapperMock.readValue(any(File.class), eq(CodeSystemEntry[].class)))
+    when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
         .thenReturn(new CodeSystemEntry[] {mappingDocEntry});
     migration.apply(
         mongoTemplateMock, codeSystemRepositoryMock, objectMapperMock, updateCodeSystemTaskMock);
@@ -210,12 +206,12 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testNewCodeSystemWithMatchingFhirAndVsacVersions() throws IOException {
+  void testNewCodeSystemWithMatchingFhirAndVsacVersions() throws JsonProcessingException {
     mappingDocEntry.setVersions(
         List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").vsac("1.0.0").build()));
     when(codeSystemRepositoryMock.findAll()).thenReturn(Collections.emptyList());
 
-    when(objectMapperMock.readValue(any(File.class), eq(CodeSystemEntry[].class)))
+    when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
         .thenReturn(new CodeSystemEntry[] {mappingDocEntry});
 
     migration.apply(
@@ -237,13 +233,13 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testNewCodeSystemWithDifferingFhirAndVsacVersions() throws IOException {
+  void testNewCodeSystemWithDifferingFhirAndVsacVersions() throws JsonProcessingException {
     mappingDocEntry.setVersions(
         List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").vsac("9.9.9").build()));
 
     when(codeSystemRepositoryMock.findAll()).thenReturn(Collections.emptyList());
 
-    when(objectMapperMock.readValue(any(File.class), eq(CodeSystemEntry[].class)))
+    when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
         .thenReturn(new CodeSystemEntry[] {mappingDocEntry});
     migration.apply(
         mongoTemplateMock, codeSystemRepositoryMock, objectMapperMock, updateCodeSystemTaskMock);
@@ -266,12 +262,12 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testNewCodeSystemWithOnlyVsacVersions() throws IOException {
+  void testNewCodeSystemWithOnlyVsacVersions() throws JsonProcessingException {
     mappingDocEntry.setVersions(List.of(CodeSystemEntry.Version.builder().vsac("9.9.9").build()));
 
     when(codeSystemRepositoryMock.findAll()).thenReturn(Collections.emptyList());
 
-    when(objectMapperMock.readValue(any(File.class), eq(CodeSystemEntry[].class)))
+    when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
         .thenReturn(new CodeSystemEntry[] {mappingDocEntry});
 
     migration.apply(
@@ -294,12 +290,12 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testNewCodeSystemWithOnlyFhirVersions() throws IOException {
+  void testNewCodeSystemWithOnlyFhirVersions() throws JsonProcessingException {
     mappingDocEntry.setVersions(List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").build()));
     mappingDocEntry.setOid("NOT.IN.VSAC.TEST");
     when(codeSystemRepositoryMock.findAll()).thenReturn(Collections.emptyList());
 
-    when(objectMapperMock.readValue(any(File.class), eq(CodeSystemEntry[].class)))
+    when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
         .thenReturn(new CodeSystemEntry[] {mappingDocEntry});
     migration.apply(
         mongoTemplateMock, codeSystemRepositoryMock, objectMapperMock, updateCodeSystemTaskMock);
@@ -320,7 +316,9 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testRollbackUsesOriginalCodeSystems() {
+  void testRollbackUsesOriginalCodeSystems() throws JsonProcessingException {
+    when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
+        .thenReturn(new CodeSystemEntry[] {mappingDocEntry});
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
 
     // Deterministic values
@@ -340,5 +338,22 @@ class LoadCodeSystemMappingDataTest {
     assertFalse(rolledBackCodeSystems.get(0).isQdm());
     assertFalse(rolledBackCodeSystems.get(0).isLatestVersion());
     assertTrue(rolledBackCodeSystems.get(0).isVsacSearchable());
+  }
+
+  @Test
+  void testRollbackDoesNothingIfMappingDocFailsParsing() throws JsonProcessingException {
+    when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
+        .thenThrow(new JsonProcessingException("Test Exception") {});
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            migration.apply(
+                mongoTemplateMock,
+                codeSystemRepositoryMock,
+                objectMapperMock,
+                updateCodeSystemTaskMock));
+    migration.rollback(mongoTemplateMock, codeSystemRepositoryMock);
+
+    verify(codeSystemRepositoryMock, never()).saveAll(anyList());
   }
 }


### PR DESCRIPTION
## Terminology Service PR

Jira Ticket: [MAT-9672](https://jira.cms.gov/browse/MAT-9672)
(Optional) Related Tickets:

### Summary

This loads the mapping doc as a Resource cus I originally forgot how to load files from jars... 

Attempt to parse the mapping doc first to avoid unnecessary DB interactions and simply rollback if parsing fails.

Updated the rollback init to build new Version objects to prevent data leakage caused by migration execution.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
