### PR TITLE
MAT-9672: Unwrap single-quoted CqlCode OID/URLs

### DIFF
--- a/src/main/java/gov/cms/madie/terminology/service/VsacService.java
+++ b/src/main/java/gov/cms/madie/terminology/service/VsacService.java
@@ -27,6 +27,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static gov.cms.madie.terminology.util.TerminologyServiceUtil.sanitizeInput;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -99,7 +101,7 @@ public class VsacService {
     cqlCode.setValid(true);
 
     // Verify Code is provided.
-    if (TerminologyServiceUtil.sanitizeInput(cqlCode.getCodeId()).isBlank()) {
+    if (sanitizeInput(cqlCode.getCodeId()).isBlank()) {
       log.info("Code Id is not available for code {}", cqlCode.getName());
       cqlCode.setValid(false);
       cqlCode.setErrorMessage("Code Id is required");
@@ -112,7 +114,7 @@ public class VsacService {
     }
 
     // Verify oid/url is provided in cql, else the code system is considered invalid.
-    String cqlCodeSystemOid = cqlCode.getCodeSystem().getOid();
+    String cqlCodeSystemOid = sanitizeInput(cqlCode.getCodeSystem().getOid());
     if (StringUtils.isBlank(cqlCodeSystemOid)) {
       log.info("CodeSystem {} does not contain any OID/URL", cqlCode.getCodeSystem().getName());
       cqlCode.getCodeSystem().setValid(false);
@@ -152,7 +154,7 @@ public class VsacService {
         TerminologyServiceUtil.buildCodePath(
             codeSystems.get(0).getName(),
             codeSystemVersion,
-            TerminologyServiceUtil.sanitizeInput(cqlCode.getCodeId()));
+            sanitizeInput(cqlCode.getCodeId()));
     VsacCode vsacCode = validateCodeAgainstVsac(codePath, umlsUser);
     // Invalid: If the statusCode is "error" and either CodeSystem or CodeSystem version
     // or Code is not found.
@@ -229,7 +231,7 @@ public class VsacService {
     // Locate the code system version that matches with user provided FHIR version
     // and return the equivalent VSAC version.
     String cqlCodeSystemVersion =
-        TerminologyServiceUtil.sanitizeInput(
+        sanitizeInput(
             cqlCode.getCodeSystem().getVersion().replace(CS_VERSION_PREFIX, ""));
 
     Optional<CodeSystem.Version> csVersion =

--- a/src/test/java/gov/cms/madie/terminology/service/VsacServiceTest.java
+++ b/src/test/java/gov/cms/madie/terminology/service/VsacServiceTest.java
@@ -82,7 +82,7 @@ class VsacServiceTest {
             .codeId("'P'")
             .codeSystem(
                 CqlCode.CqlCodeSystem.builder()
-                    .oid("'https://terminology.hl7.org/CodeSystem/v3-ActPriority'")
+                    .oid("'https://terminology.hl7.org/CodeSystem/v3-ActPriority'") // Enclosing single quotes match API usage.
                     .name("ActPriority:HL7V3.0_2021-03")
                     .version("'HL7V3.0_2021-03'")
                     .build())
@@ -97,7 +97,7 @@ class VsacServiceTest {
     var codeSystem =
         CodeSystem.builder()
             .name("ActPriority")
-            .oid("urn:oid:1.2.3.4.5.6.7.8.9")
+            .oid("'urn:oid:1.2.3.4.5.6.7.8.9'") // Enclosing single quotes match API usage.
             .fullUrl("https://terminology.hl7.org/CodeSystem/v3-ActPriority")
             .version(CodeSystem.Version.builder().vsacVersion("2.3").fhirVersion("2.3").build())
             .build();
@@ -122,7 +122,8 @@ class VsacServiceTest {
 
   @Test
   void testAValidCodeFromVsac() {
-    when(codeSystemRepository.findAllByOid(anyString())).thenReturn(codeSystems);
+    // Verifies oids wrapped in single quotes are unwrapped.
+    when(codeSystemRepository.findAllByOid(eq("https://terminology.hl7.org/CodeSystem/v3-ActPriority"))).thenReturn(codeSystems);
     when(terminologyServiceWebClient.getCode(
             eq("/CodeSystem/ActPriority/Version/HL7V3.0_2021-03/Code/P/Info"), anyString()))
         .thenReturn(vsacCode);


### PR DESCRIPTION
## Terminology Service PR

Jira Ticket: [MAT-9672](https://jira.cms.gov/browse/MAT-9672)
(Optional) Related Tickets:

### Summary

CqlCode retains the single quotes around the CodeSystem OID/URL, which need to be removed to align with the OID/URL stored in the DB. 

I goof'd and lost this cleanup during the initial refactor. Re-adding.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
