### PR TITLE
MAT-9749: Create List of Valuesets From Structured Definitions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,13 @@
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-java-models</artifactId>
-      <version>0.8.5-SNAPSHOT</version>
+      <version>0.8.9-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>gov.cms.madie</groupId>
+      <artifactId>madie-translator-commons</artifactId>
+      <version>3.0.6-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/gov/cms/madie/terminology/controller/ValueSetExpansionController.java
+++ b/src/main/java/gov/cms/madie/terminology/controller/ValueSetExpansionController.java
@@ -1,0 +1,50 @@
+package gov.cms.madie.terminology.controller;
+
+import gov.cms.madie.terminology.models.MadieValueSet;
+import gov.cms.madie.terminology.service.ValueSetExpansionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.Set;
+
+@RestController
+@RequestMapping(path = "/admin/terminology")
+@Slf4j
+@RequiredArgsConstructor
+public class ValueSetExpansionController {
+
+  private final ValueSetExpansionService vses;
+
+  @GetMapping(
+      value = "/implementation-guide/{ig}/version/{version}/value-sets",
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  @PreAuthorize("hasRole('MADIE-ADMIN')")
+  public ResponseEntity<Set<MadieValueSet>> getValueSetDependencies(
+      Principal principal, @PathVariable String ig, @PathVariable String version) {
+    log.info("Getting Value Set dependencies for IG {}, version {}", ig, version);
+    return ResponseEntity.ok(vses.getValueSetDependencies(ig, version));
+  }
+
+  @GetMapping(
+      value = "/implementation-guide/value-sets",
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  @PreAuthorize("hasRole('MADIE-ADMIN')")
+  public ResponseEntity<Map<String, Map<String, Set<MadieValueSet>>>> getValueSetDependencies(
+      Principal principal) {
+    return ResponseEntity.ok(vses.getValueSetDependencies());
+  }
+
+  @GetMapping(
+      value = "/implementation-guide/update-value-sets",
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  @PreAuthorize("hasRole('MADIE-ADMIN')")
+  public void updateValueSetDependencies(Principal principal) {
+    vses.updateValueSetDependencies();
+  }
+}

--- a/src/main/java/gov/cms/madie/terminology/models/MadieValueSet.java
+++ b/src/main/java/gov/cms/madie/terminology/models/MadieValueSet.java
@@ -1,11 +1,7 @@
 package gov.cms.madie.terminology.models;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
@@ -38,8 +34,8 @@ import java.util.List;
 @AllArgsConstructor
 @Builder(toBuilder = true)
 @NoArgsConstructor
-@Document(collection = "valueSets")
-@CompoundIndex(name = "oid_version_idx", def = "{'oid': 1, 'version': 1}", unique = true)
+@Document(collection = "valueSetExpansion")
+@EqualsAndHashCode(of = {"url", "version"})
 public class MadieValueSet {
 
   @Id private String id; // MongoDB internal ID

--- a/src/main/java/gov/cms/madie/terminology/repositories/ValueSetExpansionRepository.java
+++ b/src/main/java/gov/cms/madie/terminology/repositories/ValueSetExpansionRepository.java
@@ -1,0 +1,6 @@
+package gov.cms.madie.terminology.repositories;
+
+import gov.cms.madie.terminology.models.MadieValueSet;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ValueSetExpansionRepository extends MongoRepository<MadieValueSet, String> {}

--- a/src/main/java/gov/cms/madie/terminology/service/ValueSetExpansionService.java
+++ b/src/main/java/gov/cms/madie/terminology/service/ValueSetExpansionService.java
@@ -1,0 +1,81 @@
+package gov.cms.madie.terminology.service;
+
+import gov.cms.madie.cql_elm_translator.utils.ImplementationGuideLoader;
+import gov.cms.madie.terminology.models.MadieValueSet;
+import gov.cms.madie.terminology.repositories.ValueSetExpansionRepository;
+import gov.cms.madie.terminology.util.ImplementationGuideProcessor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.hl7.fhir.r5.model.ImplementationGuide;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ValueSetExpansionService {
+
+  private final List<ImplementationGuide> parentIgs = ImplementationGuideLoader.load();
+  private final ImplementationGuideProcessor implementationGuideProcessor;
+  private final ValueSetExpansionRepository vseRepo;
+
+  public Set<MadieValueSet> getValueSetDependencies(String igName, String version) {
+    if (CollectionUtils.isEmpty(parentIgs)) {
+      log.info("No implementation guides found.");
+      return Collections.emptySet();
+    }
+
+    ImplementationGuide parentIg =
+        parentIgs.stream()
+            .filter(
+                guide ->
+                    guide.getName().equalsIgnoreCase(igName)
+                        && guide.getVersion().equalsIgnoreCase(version))
+            .findFirst()
+            .orElse(null);
+
+    return implementationGuideProcessor.collectValueSetDependencies(parentIg).entrySet().stream()
+        .flatMap(pkgEntry -> pkgEntry.getValue().entrySet().stream())
+        .flatMap(sdEntry -> sdEntry.getValue().stream())
+        .collect(Collectors.toSet());
+  }
+
+  public Map<String, Map<String, Set<MadieValueSet>>> getValueSetDependencies() {
+    if (CollectionUtils.isEmpty(parentIgs)) {
+      return new HashMap<>();
+    }
+    Map<String, Map<String, Set<MadieValueSet>>> valueSetDependencies = new HashMap<>();
+    for (ImplementationGuide ig : parentIgs) {
+      valueSetDependencies.putAll(implementationGuideProcessor.collectValueSetDependencies(ig));
+    }
+    return valueSetDependencies;
+  }
+
+  public void updateValueSetDependencies() {
+    Set<MadieValueSet> madieValueSets =
+        getValueSetDependencies().entrySet().stream()
+            .filter(entry -> entry.getKey() != null && entry.getValue() != null)
+            .flatMap(igEntry -> igEntry.getValue().entrySet().stream())
+            .flatMap(sdEntry -> sdEntry.getValue().stream())
+            .collect(Collectors.toSet());
+
+    List<MadieValueSet> existingValueSets = vseRepo.findAll();
+
+    log.info("Found {} value set dependencies.", madieValueSets.size());
+
+    madieValueSets.removeIf(
+        vs ->
+            existingValueSets.stream()
+                .anyMatch(
+                    existingVs ->
+                        existingVs.getUrl().equals(vs.getUrl())
+                            && Objects.equals(existingVs.getVersion(), vs.getVersion())));
+
+    log.info("Saving {} new value set dependencies.", madieValueSets.size());
+
+    vseRepo.saveAll(madieValueSets);
+  }
+}

--- a/src/main/java/gov/cms/madie/terminology/util/ImplementationGuideProcessor.java
+++ b/src/main/java/gov/cms/madie/terminology/util/ImplementationGuideProcessor.java
@@ -1,0 +1,117 @@
+package gov.cms.madie.terminology.util;
+
+import ca.uhn.fhir.context.FhirContext;
+import gov.cms.madie.cql_elm_translator.utils.ImplementationGuideLoader;
+import gov.cms.madie.terminology.models.MadieValueSet;
+import lombok.extern.slf4j.Slf4j;
+import org.cqframework.fhir.npm.NpmPackageManager;
+import org.hl7.fhir.r4.model.ElementDefinition;
+import org.hl7.fhir.r4.model.StructureDefinition;
+import org.hl7.fhir.r5.model.ImplementationGuide;
+import org.hl7.fhir.utilities.npm.NpmPackage;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class ImplementationGuideProcessor {
+
+  private final ConcurrentHashMap<String, Map<String, Set<MadieValueSet>>> igValueSets =
+      new ConcurrentHashMap<>();
+  private final FhirContext ctx = FhirContext.forR4Cached();
+
+  @Value("${madie.fhir-cache}")
+  private String fhirCachePath;
+
+  public Map<String, Map<String, Set<MadieValueSet>>> collectValueSetDependencies(
+      ImplementationGuide ig) {
+    if (ig == null || !ig.hasDependsOn()) {
+      return new HashMap<>();
+    }
+
+    try {
+      List<NpmPackage> igPackages = getIgNpmPackages(ig);
+      for (NpmPackage igPkg : igPackages) {
+        String igPkgKey = igPkg.name() + igPkg.version();
+        if (igValueSets.containsKey(igPkgKey)) {
+          log.info("IG already parsed: {} v{}", igPkg.name(), igPkg.version());
+          continue;
+        }
+        igValueSets.put(igPkgKey, getBindingValueSets(igPkg));
+      }
+    } catch (IOException e) {
+      log.error("Unable to load ig package: {}", ig.getName(), e);
+    }
+    return igValueSets;
+  }
+
+  private Map<String, Set<MadieValueSet>> getBindingValueSets(NpmPackage igPkg) throws IOException {
+    List<String> structureDefFiles = getStructureDefinitionFilesForIg(igPkg);
+    if (structureDefFiles.isEmpty()) {
+      return new HashMap<>();
+    }
+    Map<String, Set<MadieValueSet>> sdValueSets = new HashMap<>();
+    for (String structureDefinition : structureDefFiles) {
+      try (InputStream sdStream = igPkg.load("package", structureDefinition)) {
+        Set<MadieValueSet> valueSetDependencies = new HashSet<>();
+
+        // Parse the StructureDefinition from JSON
+        StructureDefinition sd =
+            ctx.newJsonParser().parseResource(StructureDefinition.class, sdStream);
+        log.debug("    - {} ({})", sd.getName(), sd.getUrl());
+
+        // Check each Element for ValueSet bindings
+        for (ElementDefinition element : sd.getSnapshot().getElement()) {
+          if (element.hasBinding() && element.getBinding().hasValueSet()) {
+            MadieValueSet madieValueSet = buildMadieValueSet(element);
+            valueSetDependencies.add(madieValueSet);
+          }
+        }
+        sdValueSets.put(structureDefinition, valueSetDependencies);
+      }
+    }
+    return sdValueSets;
+  }
+
+  private @NonNull MadieValueSet buildMadieValueSet(@NonNull ElementDefinition element) {
+    String valueSetRef = element.getBinding().getValueSet();
+    log.debug("      * Element: {} binds to ValueSet: {}", element.getPath(), valueSetRef);
+    MadieValueSet madieValueSet = new MadieValueSet();
+    if (valueSetRef.contains("|")) {
+      String[] parts = valueSetRef.split("\\|");
+      madieValueSet.setUrl(parts[0]);
+      madieValueSet.setVersion(parts[1]);
+    } else {
+      madieValueSet.setUrl(valueSetRef);
+    }
+    return madieValueSet;
+  }
+
+  private List<String> getStructureDefinitionFilesForIg(NpmPackage igPkg) throws IOException {
+    if (igPkg == null) {
+      return Collections.emptyList();
+    }
+    log.info(
+        "Parsing Structure Definitions from IG Package: {} v{}", igPkg.name(), igPkg.version());
+
+    // List all StructureDefinition resources in the package
+    List<String> structureDefFiles = igPkg.listResources("StructureDefinition");
+    log.debug("  Found {} StructureDefinitions", structureDefFiles.size());
+    return structureDefFiles;
+  }
+
+  private @NonNull List<NpmPackage> getIgNpmPackages(ImplementationGuide ig) throws IOException {
+    NpmPackageManager packageManager =
+        ImplementationGuideLoader.buildPackageManager(fhirCachePath, ig);
+    // Access the downloaded NpmPackages
+    List<NpmPackage> igPackages = packageManager.getNpmList().stream().distinct().toList();
+    log.info("Loaded {} packages", igPackages.size());
+    return igPackages;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ server:
     context-path: /api
 
 madie:
+  fhir-cache: ${FHIR_CACHE_DIR:}
   allowedApi: http://localhost:9000
   user-service:
     base-url: ${USER_SERVICE_URL:http://localhost:8088/api}

--- a/src/test/java/gov/cms/madie/terminology/controller/ValueSetExpansionControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/terminology/controller/ValueSetExpansionControllerMvcTest.java
@@ -1,0 +1,254 @@
+package gov.cms.madie.terminology.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cms.madie.terminology.clients.UserServiceClient;
+import gov.cms.madie.terminology.config.SecurityConfig;
+import ca.uhn.fhir.context.FhirContext;
+import gov.cms.madie.terminology.models.MadieValueSet;
+import gov.cms.madie.terminology.service.ValueSetExpansionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ValueSetExpansionController.class)
+@Import(SecurityConfig.class)
+@ActiveProfiles("test")
+class ValueSetExpansionControllerMvcTest {
+
+  private static final String TEST_USR = "FAKE";
+  private static final String IG_NAME = "hl7.fhir.us.core";
+  private static final String IG_VERSION = "6.1.0";
+
+  @MockitoBean private ValueSetExpansionService valueSetExpansionService;
+  @MockitoBean private UserServiceClient userServiceClient;
+  @MockitoBean private FhirContext fhirContext;
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+
+  private MadieValueSet madieValueSet;
+
+  @BeforeEach
+  void setUp() {
+    madieValueSet =
+        MadieValueSet.builder()
+            .id("test-id")
+            .oid("2.16.840.1.113883.3.464.1003.101.12.1001")
+            .url("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")
+            .version("20230401")
+            .displayName("Office Visit")
+            .build();
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /admin/terminology/implementation-guide/{ig}/version/{version}/value-sets
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void getValueSetDependenciesByIgAndVersionReturnsDependencies() throws Exception {
+    when(valueSetExpansionService.getValueSetDependencies(anyString(), anyString()))
+        .thenReturn(Set.of(madieValueSet));
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.get(
+                        "/admin/terminology/implementation-guide/{ig}/version/{version}/value-sets",
+                        IG_NAME,
+                        IG_VERSION)
+                    .with(user(TEST_USR).roles("MADIE-ADMIN"))
+                    .with(csrf())
+                    .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andReturn();
+
+    assertThat(result.getResponse().getStatus(), is(equalTo(200)));
+    verify(valueSetExpansionService, times(1)).getValueSetDependencies(IG_NAME, IG_VERSION);
+  }
+
+  @Test
+  void getValueSetDependenciesByIgAndVersionReturnsForbiddenWithoutAdminRole() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(
+                    "/admin/terminology/implementation-guide/{ig}/version/{version}/value-sets",
+                    IG_NAME,
+                    IG_VERSION)
+                .with(user(TEST_USR))
+                .with(csrf())
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isForbidden());
+
+    verify(valueSetExpansionService, never()).getValueSetDependencies(anyString(), anyString());
+  }
+
+  @Test
+  void getValueSetDependenciesByIgAndVersionReturnsUnauthorizedWithoutAuthentication()
+      throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(
+                    "/admin/terminology/implementation-guide/{ig}/version/{version}/value-sets",
+                    IG_NAME,
+                    IG_VERSION)
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isUnauthorized());
+
+    verify(valueSetExpansionService, never()).getValueSetDependencies(anyString(), anyString());
+  }
+
+  @Test
+  void getValueSetDependenciesByIgAndVersionReturnsEmptySet() throws Exception {
+    when(valueSetExpansionService.getValueSetDependencies(anyString(), anyString()))
+        .thenReturn(Set.of());
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.get(
+                        "/admin/terminology/implementation-guide/{ig}/version/{version}/value-sets",
+                        IG_NAME,
+                        IG_VERSION)
+                    .with(user(TEST_USR).roles("MADIE-ADMIN"))
+                    .with(csrf())
+                    .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String body = result.getResponse().getContentAsString();
+    assertThat(body, is(equalTo("[]")));
+    verify(valueSetExpansionService, times(1)).getValueSetDependencies(IG_NAME, IG_VERSION);
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /admin/terminology/implementation-guide/value-sets
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void getAllValueSetDependenciesReturnsNestedMap() throws Exception {
+    Map<String, Map<String, Set<MadieValueSet>>> dependencyMap = new HashMap<>();
+    Map<String, Set<MadieValueSet>> sdMap = new HashMap<>();
+    sdMap.put("StructureDefinition-us-core-patient.json", Set.of(madieValueSet));
+    dependencyMap.put("hl7.fhir.us.core6.1.0", sdMap);
+
+    when(valueSetExpansionService.getValueSetDependencies()).thenReturn(dependencyMap);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/value-sets")
+                    .with(user(TEST_USR).roles("MADIE-ADMIN"))
+                    .with(csrf())
+                    .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andReturn();
+
+    assertThat(result.getResponse().getStatus(), is(equalTo(200)));
+    verify(valueSetExpansionService, times(1)).getValueSetDependencies();
+  }
+
+  @Test
+  void getAllValueSetDependenciesReturnsForbiddenWithoutAdminRole() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/value-sets")
+                .with(user(TEST_USR))
+                .with(csrf())
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isForbidden());
+
+    verify(valueSetExpansionService, never()).getValueSetDependencies();
+  }
+
+  @Test
+  void getAllValueSetDependenciesReturnsUnauthorizedWithoutAuthentication() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/value-sets")
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isUnauthorized());
+
+    verify(valueSetExpansionService, never()).getValueSetDependencies();
+  }
+
+  @Test
+  void getAllValueSetDependenciesReturnsEmptyMap() throws Exception {
+    when(valueSetExpansionService.getValueSetDependencies()).thenReturn(new HashMap<>());
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/value-sets")
+                    .with(user(TEST_USR).roles("MADIE-ADMIN"))
+                    .with(csrf())
+                    .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String body = result.getResponse().getContentAsString();
+    assertThat(body, is(equalTo("{}")));
+    verify(valueSetExpansionService, times(1)).getValueSetDependencies();
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /admin/terminology/implementation-guide/update-value-sets
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void updateValueSetDependenciesSuccessfully() throws Exception {
+    doNothing().when(valueSetExpansionService).updateValueSetDependencies();
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/update-value-sets")
+                .with(user(TEST_USR).roles("MADIE-ADMIN"))
+                .with(csrf()))
+        .andExpect(status().isOk());
+
+    verify(valueSetExpansionService, times(1)).updateValueSetDependencies();
+  }
+
+  @Test
+  void updateValueSetDependenciesReturnsForbiddenWithoutAdminRole() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/update-value-sets")
+                .with(user(TEST_USR))
+                .with(csrf()))
+        .andExpect(status().isForbidden());
+
+    verify(valueSetExpansionService, never()).updateValueSetDependencies();
+  }
+
+  @Test
+  void updateValueSetDependenciesReturnsUnauthorizedWithoutAuthentication() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/update-value-sets"))
+        .andExpect(status().isUnauthorized());
+
+    verify(valueSetExpansionService, never()).updateValueSetDependencies();
+  }
+}

--- a/src/test/java/gov/cms/madie/terminology/service/ValueSetExpansionServiceTest.java
+++ b/src/test/java/gov/cms/madie/terminology/service/ValueSetExpansionServiceTest.java
@@ -1,0 +1,351 @@
+package gov.cms.madie.terminology.service;
+
+import gov.cms.madie.cql_elm_translator.utils.ImplementationGuideLoader;
+import gov.cms.madie.terminology.models.MadieValueSet;
+import gov.cms.madie.terminology.repositories.ValueSetExpansionRepository;
+import gov.cms.madie.terminology.util.ImplementationGuideProcessor;
+import org.hl7.fhir.r5.model.ImplementationGuide;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ValueSetExpansionServiceTest {
+
+  @Mock private ImplementationGuideProcessor implementationGuideProcessor;
+  @Mock private ValueSetExpansionRepository vseRepo;
+
+  /** Builds a minimal IG with a name and version for filtering tests. */
+  private static ImplementationGuide buildIg(String name, String version) {
+    ImplementationGuide ig = new ImplementationGuide();
+    ig.setName(name);
+    ig.setVersion(version);
+    return ig;
+  }
+
+  /** Builds a MadieValueSet with a url and optional version. */
+  private static MadieValueSet buildValueSet(String url, String version) {
+    return MadieValueSet.builder().url(url).version(version).build();
+  }
+
+  // ---------------------------------------------------------------------------
+  // getValueSetDependencies(String igName, String version)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void getValueSetDependenciesByNameAndVersionReturnsEmptySetWhenNoIgsLoaded() {
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader.when(ImplementationGuideLoader::load).thenReturn(Collections.emptyList());
+
+      ValueSetExpansionService service =
+          new ValueSetExpansionService(implementationGuideProcessor, vseRepo);
+
+      Set<MadieValueSet> result = service.getValueSetDependencies("hl7.fhir.us.core", "6.1.0");
+
+      assertNotNull(result);
+      assertTrue(result.isEmpty());
+      verify(implementationGuideProcessor, never()).collectValueSetDependencies(any());
+    }
+  }
+
+  @Test
+  void getValueSetDependenciesByNameAndVersionReturnsEmptySetWhenIgNotFound() {
+    ImplementationGuide ig = buildIg("hl7.fhir.us.core", "6.1.0");
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig));
+
+      when(implementationGuideProcessor.collectValueSetDependencies(isNull()))
+          .thenReturn(new HashMap<>());
+
+      ValueSetExpansionService service =
+          new ValueSetExpansionService(implementationGuideProcessor, vseRepo);
+
+      // Request a name/version that doesn't match the loaded IG
+      Set<MadieValueSet> result = service.getValueSetDependencies("hl7.fhir.us.qicore", "5.0.0");
+
+      assertNotNull(result);
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  @Test
+  void getValueSetDependenciesByNameAndVersionReturnsValueSetsForMatchingIg() {
+    ImplementationGuide ig = buildIg("hl7.fhir.us.core", "6.1.0");
+    MadieValueSet vs1 = buildValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.2.3", "20230401");
+    MadieValueSet vs2 = buildValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/4.5.6", null);
+
+    Map<String, Map<String, Set<MadieValueSet>>> igMap = new HashMap<>();
+    Map<String, Set<MadieValueSet>> sdMap = new HashMap<>();
+    sdMap.put("StructureDefinition-us-core-patient.json", Set.of(vs1, vs2));
+    igMap.put("hl7.fhir.us.core6.1.0", sdMap);
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig));
+
+      when(implementationGuideProcessor.collectValueSetDependencies(ig)).thenReturn(igMap);
+
+      ValueSetExpansionService service =
+          new ValueSetExpansionService(implementationGuideProcessor, vseRepo);
+
+      Set<MadieValueSet> result = service.getValueSetDependencies("hl7.fhir.us.core", "6.1.0");
+
+      assertEquals(2, result.size());
+      assertTrue(result.contains(vs1));
+      assertTrue(result.contains(vs2));
+      verify(implementationGuideProcessor, times(1)).collectValueSetDependencies(ig);
+    }
+  }
+
+  @Test
+  void getValueSetDependenciesByNameAndVersionIsCaseInsensitive() {
+    ImplementationGuide ig = buildIg("hl7.fhir.us.core", "6.1.0");
+    MadieValueSet vs = buildValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.2.3", "20230401");
+
+    Map<String, Map<String, Set<MadieValueSet>>> igMap = new HashMap<>();
+    Map<String, Set<MadieValueSet>> sdMap = new HashMap<>();
+    sdMap.put("StructureDefinition-us-core-patient.json", Set.of(vs));
+    igMap.put("hl7.fhir.us.core6.1.0", sdMap);
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig));
+
+      when(implementationGuideProcessor.collectValueSetDependencies(ig)).thenReturn(igMap);
+
+      ValueSetExpansionService service =
+          new ValueSetExpansionService(implementationGuideProcessor, vseRepo);
+
+      // Pass name/version in different case
+      Set<MadieValueSet> result = service.getValueSetDependencies("HL7.FHIR.US.CORE", "6.1.0");
+
+      assertEquals(1, result.size());
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // getValueSetDependencies() — no-arg overload
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void getValueSetDependenciesReturnsEmptyMapWhenNoIgsLoaded() {
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader.when(ImplementationGuideLoader::load).thenReturn(Collections.emptyList());
+
+      ValueSetExpansionService service =
+          new ValueSetExpansionService(implementationGuideProcessor, vseRepo);
+
+      Map<String, Map<String, Set<MadieValueSet>>> result = service.getValueSetDependencies();
+
+      assertNotNull(result);
+      assertTrue(result.isEmpty());
+      verify(implementationGuideProcessor, never()).collectValueSetDependencies(any());
+    }
+  }
+
+  @Test
+  void getValueSetDependenciesAggregatesAcrossMultipleIgs() {
+    ImplementationGuide ig1 = buildIg("hl7.fhir.us.core", "6.1.0");
+    ImplementationGuide ig2 = buildIg("hl7.fhir.us.qicore", "5.0.0");
+
+    MadieValueSet vs1 = buildValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.2.3", "20230401");
+    MadieValueSet vs2 = buildValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/4.5.6", null);
+
+    Map<String, Map<String, Set<MadieValueSet>>> igMap1 = new HashMap<>();
+    igMap1.put("hl7.fhir.us.core6.1.0", Map.of("sd1.json", Set.of(vs1)));
+
+    Map<String, Map<String, Set<MadieValueSet>>> igMap2 = new HashMap<>();
+    igMap2.put("hl7.fhir.us.qicore5.0.0", Map.of("sd2.json", Set.of(vs2)));
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig1, ig2));
+
+      when(implementationGuideProcessor.collectValueSetDependencies(ig1)).thenReturn(igMap1);
+      when(implementationGuideProcessor.collectValueSetDependencies(ig2)).thenReturn(igMap2);
+
+      ValueSetExpansionService service =
+          new ValueSetExpansionService(implementationGuideProcessor, vseRepo);
+
+      Map<String, Map<String, Set<MadieValueSet>>> result = service.getValueSetDependencies();
+
+      assertEquals(2, result.size());
+      assertTrue(result.containsKey("hl7.fhir.us.core6.1.0"));
+      assertTrue(result.containsKey("hl7.fhir.us.qicore5.0.0"));
+      verify(implementationGuideProcessor, times(1)).collectValueSetDependencies(ig1);
+      verify(implementationGuideProcessor, times(1)).collectValueSetDependencies(ig2);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // updateValueSetDependencies()
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void updateValueSetDependenciesSavesNewValueSetsNotAlreadyInRepository() {
+    ImplementationGuide ig = buildIg("hl7.fhir.us.core", "6.1.0");
+    MadieValueSet newVs = buildValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/new-vs", "20230401");
+    MadieValueSet existingVs =
+        buildValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/existing-vs", "20220401");
+
+    Map<String, Map<String, Set<MadieValueSet>>> igMap = new HashMap<>();
+    igMap.put("hl7.fhir.us.core6.1.0", Map.of("sd.json", new HashSet<>(Set.of(newVs, existingVs))));
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig));
+
+      when(implementationGuideProcessor.collectValueSetDependencies(ig)).thenReturn(igMap);
+      // Repository already contains existingVs but not newVs
+      when(vseRepo.findAll()).thenReturn(List.of(existingVs));
+
+      ValueSetExpansionService service =
+          new ValueSetExpansionService(implementationGuideProcessor, vseRepo);
+      service.updateValueSetDependencies();
+
+      verify(vseRepo, times(1))
+          .saveAll(
+              argThat(
+                  saved -> {
+                    List<MadieValueSet> savedList =
+                        new ArrayList<>((Collection<MadieValueSet>) saved);
+                    return savedList.size() == 1
+                        && savedList
+                            .get(0)
+                            .getUrl()
+                            .equals("http://cts.nlm.nih.gov/fhir/ValueSet/new-vs");
+                  }));
+    }
+  }
+
+  @Test
+  void updateValueSetDependenciesSavesNothingWhenAllValueSetsAlreadyExist() {
+    ImplementationGuide ig = buildIg("hl7.fhir.us.core", "6.1.0");
+    MadieValueSet vs = buildValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.2.3", "20230401");
+
+    Map<String, Map<String, Set<MadieValueSet>>> igMap = new HashMap<>();
+    igMap.put("hl7.fhir.us.core6.1.0", Map.of("sd.json", new HashSet<>(Set.of(vs))));
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig));
+
+      when(implementationGuideProcessor.collectValueSetDependencies(ig)).thenReturn(igMap);
+      when(vseRepo.findAll()).thenReturn(List.of(vs));
+
+      ValueSetExpansionService service =
+          new ValueSetExpansionService(implementationGuideProcessor, vseRepo);
+      service.updateValueSetDependencies();
+
+      verify(vseRepo, times(1))
+          .saveAll(
+              argThat(
+                  saved -> {
+                    List<MadieValueSet> savedList =
+                        new ArrayList<>((Collection<MadieValueSet>) saved);
+                    return savedList.isEmpty();
+                  }));
+    }
+  }
+
+  @Test
+  void updateValueSetDependenciesSavesAllValueSetsWhenRepositoryIsEmpty() {
+    ImplementationGuide ig = buildIg("hl7.fhir.us.core", "6.1.0");
+    MadieValueSet vs1 = buildValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.2.3", "20230401");
+    MadieValueSet vs2 = buildValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/4.5.6", null);
+
+    Map<String, Map<String, Set<MadieValueSet>>> igMap = new HashMap<>();
+    igMap.put("hl7.fhir.us.core6.1.0", Map.of("sd.json", new HashSet<>(Set.of(vs1, vs2))));
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig));
+
+      when(implementationGuideProcessor.collectValueSetDependencies(ig)).thenReturn(igMap);
+      when(vseRepo.findAll()).thenReturn(Collections.emptyList());
+
+      ValueSetExpansionService service =
+          new ValueSetExpansionService(implementationGuideProcessor, vseRepo);
+      service.updateValueSetDependencies();
+
+      verify(vseRepo, times(1))
+          .saveAll(
+              argThat(
+                  saved -> {
+                    List<MadieValueSet> savedList =
+                        new ArrayList<>((Collection<MadieValueSet>) saved);
+                    return savedList.size() == 2;
+                  }));
+    }
+  }
+
+  @Test
+  void updateValueSetDependenciesSavesNothingWhenNoIgsLoaded() {
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader.when(ImplementationGuideLoader::load).thenReturn(Collections.emptyList());
+      when(vseRepo.findAll()).thenReturn(Collections.emptyList());
+
+      ValueSetExpansionService service =
+          new ValueSetExpansionService(implementationGuideProcessor, vseRepo);
+      service.updateValueSetDependencies();
+
+      // findAll is still called but saveAll receives an empty collection
+      verify(vseRepo, times(1)).findAll();
+      verify(vseRepo, times(1))
+          .saveAll(
+              argThat(
+                  saved -> {
+                    List<MadieValueSet> savedList =
+                        new ArrayList<>((Collection<MadieValueSet>) saved);
+                    return savedList.isEmpty();
+                  }));
+    }
+  }
+
+  @Test
+  void updateValueSetDependenciesMatchesExistingByUrlAndVersionNullVersion() {
+    ImplementationGuide ig = buildIg("hl7.fhir.us.core", "6.1.0");
+
+    // Both incoming and existing have null version — should be treated as a match
+    MadieValueSet incoming = buildValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.2.3", null);
+    MadieValueSet existing = buildValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.2.3", null);
+
+    Map<String, Map<String, Set<MadieValueSet>>> igMap = new HashMap<>();
+    igMap.put("hl7.fhir.us.core6.1.0", Map.of("sd.json", new HashSet<>(Set.of(incoming))));
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig));
+
+      when(implementationGuideProcessor.collectValueSetDependencies(ig)).thenReturn(igMap);
+      when(vseRepo.findAll()).thenReturn(List.of(existing));
+
+      ValueSetExpansionService service =
+          new ValueSetExpansionService(implementationGuideProcessor, vseRepo);
+      service.updateValueSetDependencies();
+
+      // The incoming VS matches the existing one — nothing should be saved
+      verify(vseRepo, times(1))
+          .saveAll(
+              argThat(
+                  saved -> {
+                    List<MadieValueSet> savedList =
+                        new ArrayList<>((Collection<MadieValueSet>) saved);
+                    return savedList.isEmpty();
+                  }));
+    }
+  }
+}

--- a/src/test/java/gov/cms/madie/terminology/util/ImplementationGuideProcessorTest.java
+++ b/src/test/java/gov/cms/madie/terminology/util/ImplementationGuideProcessorTest.java
@@ -1,0 +1,377 @@
+package gov.cms.madie.terminology.util;
+
+import gov.cms.madie.cql_elm_translator.utils.ImplementationGuideLoader;
+import gov.cms.madie.terminology.models.MadieValueSet;
+import org.cqframework.fhir.npm.NpmPackageManager;
+import org.hl7.fhir.r5.model.ImplementationGuide;
+import org.hl7.fhir.r5.model.ImplementationGuide.ImplementationGuideDependsOnComponent;
+import org.hl7.fhir.utilities.npm.NpmPackage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ImplementationGuideProcessorTest {
+
+  private ImplementationGuideProcessor processor;
+
+  // Minimal StructureDefinition JSON with a snapshot element that binds to a ValueSet
+  private static final String STRUCTURE_DEF_WITH_BINDING =
+      """
+      {
+        "resourceType": "StructureDefinition",
+        "id": "us-core-patient",
+        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+        "name": "USCorePatientProfile",
+        "status": "active",
+        "kind": "resource",
+        "abstract": false,
+        "type": "Patient",
+        "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+        "snapshot": {
+          "element": [
+            {
+              "id": "Patient.gender",
+              "path": "Patient.gender",
+              "binding": {
+                "strength": "required",
+                "valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1"
+              }
+            },
+            {
+              "id": "Patient.communication.language",
+              "path": "Patient.communication.language",
+              "binding": {
+                "strength": "extensible",
+                "valueSet": "http://hl7.org/fhir/us/core/ValueSet/simple-language"
+              }
+            },
+            {
+              "id": "Patient.name",
+              "path": "Patient.name",
+              "comment": "No binding on this element"
+            }
+          ]
+        }
+      }
+      """;
+
+  // StructureDefinition with no ValueSet bindings
+  private static final String STRUCTURE_DEF_WITHOUT_BINDING =
+      """
+      {
+        "resourceType": "StructureDefinition",
+        "id": "us-core-organization",
+        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+        "name": "USCoreOrganizationProfile",
+        "status": "active",
+        "kind": "resource",
+        "abstract": false,
+        "type": "Organization",
+        "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Organization",
+        "snapshot": {
+          "element": [
+            {
+              "id": "Organization.name",
+              "path": "Organization.name"
+            }
+          ]
+        }
+      }
+      """;
+
+  /**
+   * Builds a fake ImplementationGuide with a dependsOn entry, which is required for the processor
+   * to attempt parsing.
+   */
+  private static ImplementationGuide buildTestIg(String name, String version) {
+    ImplementationGuide ig = new ImplementationGuide();
+    ig.setName(name);
+    ig.setVersion(version);
+    ig.setUrl("http://hl7.org/fhir/us/core/ImplementationGuide/" + name);
+
+    ImplementationGuideDependsOnComponent dep = new ImplementationGuideDependsOnComponent();
+    dep.setUri("http://hl7.org/fhir/us/core");
+    dep.setPackageId("hl7.fhir.us.core");
+    dep.setVersion(version);
+    ig.addDependsOn(dep);
+
+    return ig;
+  }
+
+  @BeforeEach
+  void setUp() {
+    processor = new ImplementationGuideProcessor();
+  }
+
+  @Test
+  void collectValueSetDependenciesReturnsEmptyMapWhenIgIsNull() {
+    Map<String, Map<String, Set<MadieValueSet>>> result =
+        processor.collectValueSetDependencies(null);
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void collectValueSetDependenciesReturnsEmptyMapWhenIgHasNoDependencies() {
+    ImplementationGuide ig = new ImplementationGuide();
+    ig.setName("no-deps-ig");
+    // No dependsOn → hasDependsOn() returns false
+
+    Map<String, Map<String, Set<MadieValueSet>>> result = processor.collectValueSetDependencies(ig);
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void collectValueSetDependenciesExtractsValueSetBindings() throws IOException {
+    ImplementationGuide ig = buildTestIg("hl7.fhir.us.core", "6.1.0");
+
+    NpmPackage mockPackage = mock(NpmPackage.class);
+    when(mockPackage.name()).thenReturn("hl7.fhir.us.core");
+    when(mockPackage.version()).thenReturn("6.1.0");
+    when(mockPackage.listResources("StructureDefinition"))
+        .thenReturn(List.of("StructureDefinition-us-core-patient.json"));
+    when(mockPackage.load("package", "StructureDefinition-us-core-patient.json"))
+        .thenReturn(toInputStream(STRUCTURE_DEF_WITH_BINDING));
+
+    NpmPackageManager mockPm = mock(NpmPackageManager.class);
+    when(mockPm.getNpmList()).thenReturn(List.of(mockPackage));
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader
+          .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), any()))
+          .thenReturn(mockPm);
+
+      Map<String, Map<String, Set<MadieValueSet>>> result =
+          processor.collectValueSetDependencies(ig);
+
+      assertNotNull(result);
+      assertEquals(1, result.size());
+      assertTrue(result.containsKey("hl7.fhir.us.core6.1.0"));
+
+      Map<String, Set<MadieValueSet>> sdMap = result.get("hl7.fhir.us.core6.1.0");
+      assertNotNull(sdMap);
+      assertEquals(1, sdMap.size());
+
+      Set<MadieValueSet> valueSets = sdMap.get("StructureDefinition-us-core-patient.json");
+      assertNotNull(valueSets);
+      assertEquals(2, valueSets.size());
+
+      // Verify the versioned ValueSet binding was parsed correctly
+      assertTrue(
+          valueSets.stream()
+              .anyMatch(
+                  vs ->
+                      "http://hl7.org/fhir/ValueSet/administrative-gender".equals(vs.getUrl())
+                          && "4.0.1".equals(vs.getVersion())));
+      // Verify the unversioned ValueSet binding
+      assertTrue(
+          valueSets.stream()
+              .anyMatch(
+                  vs ->
+                      "http://hl7.org/fhir/us/core/ValueSet/simple-language".equals(vs.getUrl())
+                          && vs.getVersion() == null));
+    }
+  }
+
+  @Test
+  void collectValueSetDependenciesHandlesStructureDefWithNoBindings() throws IOException {
+    ImplementationGuide ig = buildTestIg("hl7.fhir.us.core", "6.1.0");
+
+    NpmPackage mockPackage = mock(NpmPackage.class);
+    when(mockPackage.name()).thenReturn("hl7.fhir.us.core");
+    when(mockPackage.version()).thenReturn("6.1.0");
+    when(mockPackage.listResources("StructureDefinition"))
+        .thenReturn(List.of("StructureDefinition-us-core-organization.json"));
+    when(mockPackage.load("package", "StructureDefinition-us-core-organization.json"))
+        .thenReturn(toInputStream(STRUCTURE_DEF_WITHOUT_BINDING));
+
+    NpmPackageManager mockPm = mock(NpmPackageManager.class);
+    when(mockPm.getNpmList()).thenReturn(List.of(mockPackage));
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader
+          .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), any()))
+          .thenReturn(mockPm);
+
+      Map<String, Map<String, Set<MadieValueSet>>> result =
+          processor.collectValueSetDependencies(ig);
+
+      assertNotNull(result);
+      Map<String, Set<MadieValueSet>> sdMap = result.get("hl7.fhir.us.core6.1.0");
+      assertNotNull(sdMap);
+      Set<MadieValueSet> valueSets = sdMap.get("StructureDefinition-us-core-organization.json");
+      assertNotNull(valueSets);
+      assertTrue(valueSets.isEmpty(), "No bindings should produce an empty set");
+    }
+  }
+
+  @Test
+  void collectValueSetDependenciesHandlesMultiplePackages() throws IOException {
+    ImplementationGuide ig = buildTestIg("composite-ig", "1.0.0");
+
+    NpmPackage pkg1 = mock(NpmPackage.class);
+    when(pkg1.name()).thenReturn("hl7.fhir.us.core");
+    when(pkg1.version()).thenReturn("6.1.0");
+    when(pkg1.listResources("StructureDefinition"))
+        .thenReturn(List.of("StructureDefinition-us-core-patient.json"));
+    when(pkg1.load("package", "StructureDefinition-us-core-patient.json"))
+        .thenReturn(toInputStream(STRUCTURE_DEF_WITH_BINDING));
+
+    NpmPackage pkg2 = mock(NpmPackage.class);
+    when(pkg2.name()).thenReturn("hl7.fhir.us.qicore");
+    when(pkg2.version()).thenReturn("5.0.0");
+    when(pkg2.listResources("StructureDefinition"))
+        .thenReturn(List.of("StructureDefinition-us-core-organization.json"));
+    when(pkg2.load("package", "StructureDefinition-us-core-organization.json"))
+        .thenReturn(toInputStream(STRUCTURE_DEF_WITHOUT_BINDING));
+
+    NpmPackageManager mockPm = mock(NpmPackageManager.class);
+    when(mockPm.getNpmList()).thenReturn(List.of(pkg1, pkg2));
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader
+          .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), any()))
+          .thenReturn(mockPm);
+
+      Map<String, Map<String, Set<MadieValueSet>>> result =
+          processor.collectValueSetDependencies(ig);
+
+      assertEquals(2, result.size());
+      assertTrue(result.containsKey("hl7.fhir.us.core6.1.0"));
+      assertTrue(result.containsKey("hl7.fhir.us.qicore5.0.0"));
+    }
+  }
+
+  @Test
+  void collectValueSetDependenciesSkipsAlreadyParsedPackages() throws IOException {
+    ImplementationGuide ig = buildTestIg("hl7.fhir.us.core", "6.1.0");
+
+    NpmPackage mockPackage = mock(NpmPackage.class);
+    when(mockPackage.name()).thenReturn("hl7.fhir.us.core");
+    when(mockPackage.version()).thenReturn("6.1.0");
+    when(mockPackage.listResources("StructureDefinition"))
+        .thenReturn(List.of("StructureDefinition-us-core-patient.json"));
+    when(mockPackage.load("package", "StructureDefinition-us-core-patient.json"))
+        .thenReturn(toInputStream(STRUCTURE_DEF_WITH_BINDING));
+
+    NpmPackageManager mockPm = mock(NpmPackageManager.class);
+    when(mockPm.getNpmList()).thenReturn(List.of(mockPackage));
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader
+          .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), any()))
+          .thenReturn(mockPm);
+
+      // First call — parses the package
+      processor.collectValueSetDependencies(ig);
+      // Second call — same IG, package should be skipped (cached)
+      Map<String, Map<String, Set<MadieValueSet>>> result =
+          processor.collectValueSetDependencies(ig);
+
+      assertNotNull(result);
+      assertEquals(1, result.size());
+      // listResources should only have been called once (first parse)
+      verify(mockPackage, times(1)).listResources("StructureDefinition");
+    }
+  }
+
+  @Test
+  void collectValueSetDependenciesHandlesEmptyStructureDefinitionList() throws IOException {
+    ImplementationGuide ig = buildTestIg("empty-ig", "1.0.0");
+
+    NpmPackage mockPackage = mock(NpmPackage.class);
+    when(mockPackage.name()).thenReturn("empty-ig");
+    when(mockPackage.version()).thenReturn("1.0.0");
+    when(mockPackage.listResources("StructureDefinition")).thenReturn(Collections.emptyList());
+
+    NpmPackageManager mockPm = mock(NpmPackageManager.class);
+    when(mockPm.getNpmList()).thenReturn(List.of(mockPackage));
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader
+          .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), any()))
+          .thenReturn(mockPm);
+
+      Map<String, Map<String, Set<MadieValueSet>>> result =
+          processor.collectValueSetDependencies(ig);
+
+      assertNotNull(result);
+      assertTrue(result.containsKey("empty-ig1.0.0"));
+      Map<String, Set<MadieValueSet>> sdMap = result.get("empty-ig1.0.0");
+      assertNotNull(sdMap);
+      assertTrue(sdMap.isEmpty());
+    }
+  }
+
+  @Test
+  void collectValueSetDependenciesHandlesNullPackageGracefully() throws IOException {
+    ImplementationGuide ig = buildTestIg("null-pkg-ig", "1.0.0");
+
+    // NpmPackageManager returns a list with a null package
+    NpmPackage nullPkg = mock(NpmPackage.class);
+    when(nullPkg.name()).thenReturn("null-pkg-ig");
+    when(nullPkg.version()).thenReturn("1.0.0");
+    // listResources on a null-like package returns empty
+    when(nullPkg.listResources("StructureDefinition")).thenReturn(Collections.emptyList());
+
+    NpmPackageManager mockPm = mock(NpmPackageManager.class);
+    when(mockPm.getNpmList()).thenReturn(List.of(nullPkg));
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader
+          .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), any()))
+          .thenReturn(mockPm);
+
+      Map<String, Map<String, Set<MadieValueSet>>> result =
+          processor.collectValueSetDependencies(ig);
+
+      assertNotNull(result);
+    }
+  }
+
+  @Test
+  void collectValueSetDependenciesLogsAndReturnsOnIOException() throws IOException {
+    ImplementationGuide ig = buildTestIg("failing-ig", "1.0.0");
+
+    try (MockedStatic<ImplementationGuideLoader> loader =
+        mockStatic(ImplementationGuideLoader.class)) {
+      loader
+          .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), any()))
+          .thenThrow(new IOException("Simulated network failure"));
+
+      Map<String, Map<String, Set<MadieValueSet>>> result =
+          processor.collectValueSetDependencies(ig);
+
+      // Should return the (empty) igValueSets map without throwing
+      assertNotNull(result);
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  private static InputStream toInputStream(String content) {
+    return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
## Terminology Service PR

Jira Ticket: [MAT-9749](https://jira.cms.gov/browse/MAT-9749)
(Optional) Related Tickets:

### Summary

Do a bunch of stuff to get at the Value Set binding info (FHIR URLs):

1. Read the "parent" IGs. 
     These are IGs we make and maintain that point at the true model IGs as dependencies. This is necessary to accommodate design decisions of the `NpmPackageManager` maintained by cqframework.
2. Use the `NpmPackageManager` to retrieve all of the IGs needed for each Parent IG.
    One Parent IG per model, qicore 4.1.1, 6.0.0, etc. `NpmPackageManager` will download the NPM packages for each model as well as any other IG NPM Packages indicated as dependency by the already downloaded IGs.
3. Perform a depth first parse of the StructureDefinitions in each IG. 
4. Perform a depth first parse of every element in each StructureDefinition for any value set binding.
5. Record the FHIR URL for every value set binding into a Set.
6. Report the Set to the caller.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
