### PR TITLE
MAT-9911: Treat all FHIR Code System Versions as 'Not in VSAC' if any entry is marked as 'NOT.IN.VSAC'

### DIFF
--- a/src/main/java/gov/cms/madie/terminology/service/VsacService.java
+++ b/src/main/java/gov/cms/madie/terminology/service/VsacService.java
@@ -136,11 +136,13 @@ public class VsacService {
       return;
     }
 
-    // if all code system versions are listed as NOT IN VSAC, then it is a valid FHIR code system.
+    // if FHIR and any code system version is listed as NOT IN VSAC, then it is a valid FHIR code
+    // system.
     cqlCode.getCodeSystem().setValid(true);
     if (targetCodeSystemVersions.stream()
+        .filter(CodeSystem::isFhir)
         .map(CodeSystem::getOid)
-        .allMatch(oid -> oid.contains("NOT.IN.VSAC"))) {
+        .anyMatch(oid -> oid.contains("NOT.IN.VSAC"))) {
       return;
     }
 


### PR DESCRIPTION
## Terminology Service PR

Jira Ticket: [MAT-9911](https://jira.cms.gov/browse/MAT-9911)
(Optional) Related Tickets:

### Summary

When validating FHIR Code Systems in CQL, to better mimic the code-system-entry mapping document behavior, if any Version entry is marked as "NOT IN VSAC", treat all FHIR Versions of that Code System as "NOT IN VSAC". 

A FHIR Code System "NOT IN VSAC" are defaulted to valid, skipping external validation.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
