### PR TITLE
MAT-9749: Match existing admin endpoint paths (/terminology/admin).

### DIFF
--- a/src/main/java/gov/cms/madie/terminology/controller/ValueSetExpansionController.java
+++ b/src/main/java/gov/cms/madie/terminology/controller/ValueSetExpansionController.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.Set;
 
 @RestController
-@RequestMapping(path = "/admin/terminology")
+@RequestMapping(path = "/terminology/admin")
 @Slf4j
 @RequiredArgsConstructor
 public class ValueSetExpansionController {

--- a/src/test/java/gov/cms/madie/terminology/controller/ValueSetExpansionControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/terminology/controller/ValueSetExpansionControllerMvcTest.java
@@ -61,7 +61,7 @@ class ValueSetExpansionControllerMvcTest {
   }
 
   // ---------------------------------------------------------------------------
-  // GET /admin/terminology/implementation-guide/{ig}/version/{version}/value-sets
+  // GET /terminology/admin/implementation-guide/{ig}/version/{version}/value-sets
   // ---------------------------------------------------------------------------
 
   @Test
@@ -73,7 +73,7 @@ class ValueSetExpansionControllerMvcTest {
         mockMvc
             .perform(
                 MockMvcRequestBuilders.get(
-                        "/admin/terminology/implementation-guide/{ig}/version/{version}/value-sets",
+                        "/terminology/admin/implementation-guide/{ig}/version/{version}/value-sets",
                         IG_NAME,
                         IG_VERSION)
                     .with(user(TEST_USR).roles("MADIE-ADMIN"))
@@ -92,7 +92,7 @@ class ValueSetExpansionControllerMvcTest {
     mockMvc
         .perform(
             MockMvcRequestBuilders.get(
-                    "/admin/terminology/implementation-guide/{ig}/version/{version}/value-sets",
+                    "/terminology/admin/implementation-guide/{ig}/version/{version}/value-sets",
                     IG_NAME,
                     IG_VERSION)
                 .with(user(TEST_USR))
@@ -109,7 +109,7 @@ class ValueSetExpansionControllerMvcTest {
     mockMvc
         .perform(
             MockMvcRequestBuilders.get(
-                    "/admin/terminology/implementation-guide/{ig}/version/{version}/value-sets",
+                    "/terminology/admin/implementation-guide/{ig}/version/{version}/value-sets",
                     IG_NAME,
                     IG_VERSION)
                 .accept(MediaType.APPLICATION_JSON_VALUE))
@@ -127,7 +127,7 @@ class ValueSetExpansionControllerMvcTest {
         mockMvc
             .perform(
                 MockMvcRequestBuilders.get(
-                        "/admin/terminology/implementation-guide/{ig}/version/{version}/value-sets",
+                        "/terminology/admin/implementation-guide/{ig}/version/{version}/value-sets",
                         IG_NAME,
                         IG_VERSION)
                     .with(user(TEST_USR).roles("MADIE-ADMIN"))
@@ -142,7 +142,7 @@ class ValueSetExpansionControllerMvcTest {
   }
 
   // ---------------------------------------------------------------------------
-  // GET /admin/terminology/implementation-guide/value-sets
+  // GET /terminology/admin/implementation-guide/value-sets
   // ---------------------------------------------------------------------------
 
   @Test
@@ -157,7 +157,7 @@ class ValueSetExpansionControllerMvcTest {
     MvcResult result =
         mockMvc
             .perform(
-                MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/value-sets")
+                MockMvcRequestBuilders.get("/terminology/admin/implementation-guide/value-sets")
                     .with(user(TEST_USR).roles("MADIE-ADMIN"))
                     .with(csrf())
                     .accept(MediaType.APPLICATION_JSON_VALUE))
@@ -173,7 +173,7 @@ class ValueSetExpansionControllerMvcTest {
   void getAllValueSetDependenciesReturnsForbiddenWithoutAdminRole() throws Exception {
     mockMvc
         .perform(
-            MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/value-sets")
+            MockMvcRequestBuilders.get("/terminology/admin/implementation-guide/value-sets")
                 .with(user(TEST_USR))
                 .with(csrf())
                 .accept(MediaType.APPLICATION_JSON_VALUE))
@@ -186,7 +186,7 @@ class ValueSetExpansionControllerMvcTest {
   void getAllValueSetDependenciesReturnsUnauthorizedWithoutAuthentication() throws Exception {
     mockMvc
         .perform(
-            MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/value-sets")
+            MockMvcRequestBuilders.get("/terminology/admin/implementation-guide/value-sets")
                 .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isUnauthorized());
 
@@ -200,7 +200,7 @@ class ValueSetExpansionControllerMvcTest {
     MvcResult result =
         mockMvc
             .perform(
-                MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/value-sets")
+                MockMvcRequestBuilders.get("/terminology/admin/implementation-guide/value-sets")
                     .with(user(TEST_USR).roles("MADIE-ADMIN"))
                     .with(csrf())
                     .accept(MediaType.APPLICATION_JSON_VALUE))
@@ -213,7 +213,7 @@ class ValueSetExpansionControllerMvcTest {
   }
 
   // ---------------------------------------------------------------------------
-  // GET /admin/terminology/implementation-guide/update-value-sets
+  // GET /terminology/admin/implementation-guide/update-value-sets
   // ---------------------------------------------------------------------------
 
   @Test
@@ -222,7 +222,7 @@ class ValueSetExpansionControllerMvcTest {
 
     mockMvc
         .perform(
-            MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/update-value-sets")
+            MockMvcRequestBuilders.get("/terminology/admin/implementation-guide/update-value-sets")
                 .with(user(TEST_USR).roles("MADIE-ADMIN"))
                 .with(csrf()))
         .andExpect(status().isOk());
@@ -234,7 +234,7 @@ class ValueSetExpansionControllerMvcTest {
   void updateValueSetDependenciesReturnsForbiddenWithoutAdminRole() throws Exception {
     mockMvc
         .perform(
-            MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/update-value-sets")
+            MockMvcRequestBuilders.get("/terminology/admin/implementation-guide/update-value-sets")
                 .with(user(TEST_USR))
                 .with(csrf()))
         .andExpect(status().isForbidden());
@@ -246,7 +246,7 @@ class ValueSetExpansionControllerMvcTest {
   void updateValueSetDependenciesReturnsUnauthorizedWithoutAuthentication() throws Exception {
     mockMvc
         .perform(
-            MockMvcRequestBuilders.get("/admin/terminology/implementation-guide/update-value-sets"))
+            MockMvcRequestBuilders.get("/terminology/admin/implementation-guide/update-value-sets"))
         .andExpect(status().isUnauthorized());
 
     verify(valueSetExpansionService, never()).updateValueSetDependencies();


### PR DESCRIPTION
## Terminology Service PR

Jira Ticket: [MAT-9749](https://jira.cms.gov/browse/MAT-9749)
(Optional) Related Tickets:

### Summary

I goof'd in the original path setup by swapping `/terminology/admin` to `/admin/terminology`. This caused devops to use an extra path rule (which are limited to 5 before we have to request exceptions). Swapping the path segments back to match existing admin endpoints.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
