### PR TITLE
MAT-9980: normalize harpId to lowercase for case-insensitive UMLS key lookup

### DIFF
--- a/src/main/java/gov/cms/madie/terminology/service/VsacService.java
+++ b/src/main/java/gov/cms/madie/terminology/service/VsacService.java
@@ -297,16 +297,21 @@ public class VsacService {
   public UmlsUser saveUmlsUser(String harpId, String apiKey) {
     Instant now = Instant.now();
     UmlsUser umlsUser =
-        UmlsUser.builder().apiKey(apiKey).harpId(harpId).createdAt(now).modifiedAt(now).build();
+        UmlsUser.builder()
+            .apiKey(apiKey)
+            .harpId(harpId.toLowerCase())
+            .createdAt(now)
+            .modifiedAt(now)
+            .build();
     return umlsUserRepository.save(umlsUser);
   }
 
   public Optional<UmlsUser> findByHarpId(String harpId) {
-    return umlsUserRepository.findByHarpId(harpId);
+    return umlsUserRepository.findByHarpId(harpId.toLowerCase());
   }
 
   public boolean logoutUMLSUser(String userName) {
-    Optional<UmlsUser> deletedUser = umlsUserRepository.deleteByHarpId(userName);
+    Optional<UmlsUser> deletedUser = umlsUserRepository.deleteByHarpId(userName.toLowerCase());
     boolean deleted = deletedUser.isPresent();
     if (deleted) {
       log.info("Successfully deleted UMLS information for User Name: {}", userName);

--- a/src/test/java/gov/cms/madie/terminology/service/VsacServiceTest.java
+++ b/src/test/java/gov/cms/madie/terminology/service/VsacServiceTest.java
@@ -763,4 +763,27 @@ class VsacServiceTest {
     assertFalse(cqlCode.isValid());
     assertNull(cqlCode.getErrorMessage());
   }
+
+  @Test
+  void saveUmlsUserNormalizesHarpIdToLowerCase() {
+    ArgumentCaptor<UmlsUser> captor = ArgumentCaptor.forClass(UmlsUser.class);
+    doReturn(umlsUser).when(umlsUserRepository).save(any(UmlsUser.class));
+    vsacService.saveUmlsUser("MixedCaseUser", TEST_API_KEY);
+    verify(umlsUserRepository).save(captor.capture());
+    assertEquals("mixedcaseuser", captor.getValue().getHarpId());
+  }
+
+  @Test
+  void findByHarpIdNormalizesInputToLowerCase() {
+    doReturn(Optional.of(umlsUser)).when(umlsUserRepository).findByHarpId(anyString());
+    vsacService.findByHarpId("MixedCaseUser");
+    verify(umlsUserRepository).findByHarpId(eq("mixedcaseuser"));
+  }
+
+  @Test
+  void logoutUMLSUserNormalizesUserNameToLowerCase() {
+    doReturn(Optional.of(umlsUser)).when(umlsUserRepository).deleteByHarpId(anyString());
+    vsacService.logoutUMLSUser("MixedCaseUser");
+    verify(umlsUserRepository).deleteByHarpId(eq("mixedcaseuser"));
+  }
 }


### PR DESCRIPTION
## Terminology Service PR

Jira Ticket: [MAT-9980](https://jira.cms.gov/browse/MAT-9980)
(Optional) Related Tickets:

### Summary

When retrieving a user's UMLS key from the umlsUser collection, the harpId lookup was case-sensitive. If the Okta JWT subject claim arrived with different casing than what was stored, the lookup returned empty and the user received an unauthorized error despite having a valid key in the DB.

This PR lowercased harpId at all three DB touch points in VsacService: saveUmlsUser, findByHarpId, and logoutUMLSUser.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
