### PR TITLE
MAT-10059: update spring boot (from 3.5.14 to 4.0.7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.7</version>
     <relativePath></relativePath>
     <!-- lookup parent from repository -->
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.14</version>
+    <version>4.0.6</version>
     <relativePath></relativePath>
     <!-- lookup parent from repository -->
   </parent>
@@ -15,7 +15,7 @@
   <description>Terminology Service for MADiE</description>
   <properties>
     <hapifhir.version>8.10.0</hapifhir.version>
-    <java.version>16</java.version>
+    <java.version>17</java.version>
     <jxbmavenplugin.version>3.2.0</jxbmavenplugin.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
@@ -30,7 +30,7 @@
     <mvn.checkstyle.version>3.1.2</mvn.checkstyle.version>
     <mvnreports.version>3.2.2</mvnreports.version>
     <mvnsite.version>3.11.0</mvnsite.version>
-    <okta.springboot.starter.version>3.0.7</okta.springboot.starter.version>
+    <okta.springboot.starter.version>3.1.0</okta.springboot.starter.version>
     <puppycrawl.checkstyle.version>10.1</puppycrawl.checkstyle.version>
   </properties>
 
@@ -49,7 +49,7 @@
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot-starter-webmvc</artifactId>
       <exclusions>
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
@@ -72,6 +72,18 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security-oauth2-resource-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security-oauth2-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -108,6 +120,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webclient</artifactId>
+    </dependency>
 
     <!-- https://mvnrepository.com/artifact/ca.uhn.hapi.fhir/hapi-fhir-structures-r4 -->
     <dependency>
@@ -125,13 +141,13 @@
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-java-models</artifactId>
-      <version>0.8.9-SNAPSHOT</version>
+      <version>0.10.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-translator-commons</artifactId>
-      <version>3.1.1</version>
+      <version>3.5.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.jetbrains.kotlinx</groupId>
@@ -153,6 +169,11 @@
     <dependency>
       <groupId>io.mongock</groupId>
       <artifactId>mongodb-springdata-v4-driver</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-webmvc-test</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/src/main/java/gov/cms/madie/terminology/config/SecurityConfig.java
+++ b/src/main/java/gov/cms/madie/terminology/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.header.HeaderWriterFilter;
@@ -13,6 +14,7 @@ import org.springframework.security.web.header.writers.XXssProtectionHeaderWrite
 import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
+@EnableWebSecurity
 @EnableMethodSecurity
 public class SecurityConfig {
 

--- a/src/main/java/gov/cms/madie/terminology/config/UserServiceClientConfig.java
+++ b/src/main/java/gov/cms/madie/terminology/config/UserServiceClientConfig.java
@@ -1,14 +1,12 @@
 package gov.cms.madie.terminology.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -18,15 +16,8 @@ import org.springframework.web.client.RestTemplate;
 public class UserServiceClientConfig {
 
   @Bean
-  public RestTemplate userServiceRestTemplate(ObjectMapper objectMapper) {
-    MappingJackson2HttpMessageConverter messageConverter =
-        new MappingJackson2HttpMessageConverter();
-    messageConverter.setObjectMapper(objectMapper);
-
-    return new RestTemplateBuilder()
-        .additionalMessageConverters(messageConverter)
-        .additionalInterceptors(bearerTokenInterceptor())
-        .build();
+  public RestTemplate userServiceRestTemplate(RestTemplateBuilder builder) {
+    return builder.additionalInterceptors(bearerTokenInterceptor()).build();
   }
 
   private ClientHttpRequestInterceptor bearerTokenInterceptor() {

--- a/src/main/java/gov/cms/madie/terminology/config/migrations/LoadCodeSystemMappingData.java
+++ b/src/main/java/gov/cms/madie/terminology/config/migrations/LoadCodeSystemMappingData.java
@@ -1,6 +1,7 @@
 package gov.cms.madie.terminology.config.migrations;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import gov.cms.madie.models.mapping.CodeSystemEntry;
 import gov.cms.madie.terminology.models.CodeSystem;
 import gov.cms.madie.terminology.repositories.CodeSystemRepository;
@@ -132,7 +133,7 @@ public class LoadCodeSystemMappingData {
             "/code-system-entry.json");
         return Arrays.asList(entries);
       }
-    } catch (IOException e) {
+    } catch (JacksonException e) {
       log.error("Error deserializing CodeSystemEntry from file: {}", "/code-system-entry.json", e);
     }
     return Collections.emptyList();

--- a/src/main/java/gov/cms/madie/terminology/controller/VsacControllerAdvice.java
+++ b/src/main/java/gov/cms/madie/terminology/controller/VsacControllerAdvice.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
-import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.boot.webmvc.error.ErrorAttributes;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -44,17 +44,17 @@ public class VsacControllerAdvice {
       WebClientResponseException ex, WebRequest request) {
     log.error(
         "Error from WebClient - Status {}, Message {}, Body {}",
-        ex.getRawStatusCode(),
+        ex.getStatusCode().value(),
         ex.getLocalizedMessage(),
         ex.getResponseBodyAsString());
     Map<String, String> validationErrors = new HashMap<>();
     validationErrors.put(request.getContextPath(), ex.getLocalizedMessage());
 
     Map<String, Object> errorAttributes =
-        getErrorAttributes(request, HttpStatus.valueOf(ex.getRawStatusCode()));
+        getErrorAttributes(request, HttpStatus.valueOf(ex.getStatusCode().value()));
     errorAttributes.put("validationErrors", validationErrors);
 
-    return ResponseEntity.status(ex.getRawStatusCode())
+    return ResponseEntity.status(ex.getStatusCode().value())
         .contentType(MediaType.APPLICATION_JSON)
         .body(errorAttributes);
   }

--- a/src/main/java/gov/cms/madie/terminology/dto/ValueSetsSearchCriteria.java
+++ b/src/main/java/gov/cms/madie/terminology/dto/ValueSetsSearchCriteria.java
@@ -1,13 +1,17 @@
 package gov.cms.madie.terminology.dto;
 
 import gov.cms.madie.models.measure.ManifestExpansion;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
+@AllArgsConstructor
 @Builder(toBuilder = true)
+@NoArgsConstructor
 public class ValueSetsSearchCriteria {
 
   private String profile;
@@ -17,7 +21,9 @@ public class ValueSetsSearchCriteria {
   private List<ValueSetParams> valueSetParams;
 
   @Data
+  @AllArgsConstructor
   @Builder
+  @NoArgsConstructor
   public static class ValueSetParams {
     private String oid;
     private String release;

--- a/src/main/java/gov/cms/madie/terminology/models/CodeSystem.java
+++ b/src/main/java/gov/cms/madie/terminology/models/CodeSystem.java
@@ -48,7 +48,9 @@ public class CodeSystem {
   }
 
   @Data
+  @AllArgsConstructor
   @Builder(toBuilder = true)
+  @NoArgsConstructor
   public static class Version {
     @NotBlank private String fhirVersion;
     private String vsacVersion;

--- a/src/main/java/gov/cms/madie/terminology/service/FhirTerminologyService.java
+++ b/src/main/java/gov/cms/madie/terminology/service/FhirTerminologyService.java
@@ -402,7 +402,7 @@ public class FhirTerminologyService {
         (l) -> {
           if (l.getRelation().equals("next")) {
             // if next, call self and continue until fail.
-            UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(l.getUrl());
+            UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(l.getUrl());
             String newOffset = builder.build().getQueryParams().getFirst("_offset");
             String newCount = builder.build().getQueryParams().getFirst("_count");
             assert newOffset != null;

--- a/src/main/java/gov/cms/madie/terminology/util/ImplementationGuideManager.java
+++ b/src/main/java/gov/cms/madie/terminology/util/ImplementationGuideManager.java
@@ -48,7 +48,7 @@ public class ImplementationGuideManager {
     log.info("Implementation guide manager::loading implementation guide packages.");
     Instant now = Instant.now();
     igLoadingState = IgLoadingState.LOADING;
-    List<ImplementationGuide> madieIgs = ImplementationGuideLoader.load();
+    List<ImplementationGuide> madieIgs = ImplementationGuideLoader.load("classpath*:igs/*.json");
     for (ImplementationGuide madieIg : madieIgs) {
       collectValueSetDependencies(madieIg);
     }

--- a/src/main/java/gov/cms/madie/terminology/webclient/FhirTerminologyServiceWebClient.java
+++ b/src/main/java/gov/cms/madie/terminology/webclient/FhirTerminologyServiceWebClient.java
@@ -168,9 +168,9 @@ public class FhirTerminologyServiceWebClient {
         .accept(new MediaType("application", "fhir+json", Charset.defaultCharset()))
         .exchangeToMono(
             clientResponse -> {
-              if (clientResponse.statusCode().equals(HttpStatus.OK)) {
+              if (clientResponse.statusCode().isSameCodeAs(HttpStatus.OK)) {
                 return clientResponse.bodyToMono(String.class);
-              } else if (clientResponse.statusCode().equals(HttpStatus.NOT_FOUND)) {
+              } else if (clientResponse.statusCode().isSameCodeAs(HttpStatus.NOT_FOUND)) {
                 log.debug("Received NOT_FOUND response while retrieving {}", resourceType);
                 return clientResponse
                     .createException()
@@ -214,7 +214,7 @@ public class FhirTerminologyServiceWebClient {
             .accept(new MediaType("application", "fhir+json", Charset.defaultCharset()))
             .exchangeToMono(
                 clientResponse -> {
-                  if (clientResponse.statusCode().equals(HttpStatus.OK)) {
+                  if (clientResponse.statusCode().isSameCodeAs(HttpStatus.OK)) {
                     return clientResponse.bodyToMono(String.class);
                   } else {
                     return clientResponse

--- a/src/main/java/gov/cms/madie/terminology/webclient/TerminologyServiceWebClient.java
+++ b/src/main/java/gov/cms/madie/terminology/webclient/TerminologyServiceWebClient.java
@@ -81,8 +81,8 @@ public class TerminologyServiceWebClient {
         .headers(headers -> headers.setBasicAuth("apikey", apiKey))
         .exchangeToMono(
             clientResponse -> {
-              if (clientResponse.statusCode().equals(HttpStatus.BAD_REQUEST)
-                  || clientResponse.statusCode().equals(HttpStatus.OK)) {
+              if (clientResponse.statusCode().isSameCodeAs(HttpStatus.BAD_REQUEST)
+                  || clientResponse.statusCode().isSameCodeAs(HttpStatus.OK)) {
                 return clientResponse.bodyToMono(VsacCode.class);
               } else {
                 log.info("Received NON-OK response while retrieving codePath {}", codePath);

--- a/src/main/java/gov/cms/madie/terminology/webclient/TxTerminologyServiceWebClient.java
+++ b/src/main/java/gov/cms/madie/terminology/webclient/TxTerminologyServiceWebClient.java
@@ -93,10 +93,10 @@ public class TxTerminologyServiceWebClient {
         .accept(new MediaType("application", "json+fhir", Charset.defaultCharset()))
         .exchangeToMono(
             clientResponse -> {
-              if (clientResponse.statusCode().equals(HttpStatus.OK)) {
+              if (clientResponse.statusCode().isSameCodeAs(HttpStatus.OK)) {
                 return clientResponse.bodyToMono(String.class);
               }
-              if (clientResponse.statusCode().equals(HttpStatus.UNPROCESSABLE_ENTITY)) {
+              if (clientResponse.statusCode().isSameCodeAs(HttpStatus.UNPROCESSABLE_ENTITY)) {
                 return clientResponse
                     .bodyToMono(String.class)
                     .flatMap(

--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -1,6 +1,5 @@
 spring:
-   data:
+   mongodb:
       database: ${MONGO_DATABASE}
-      mongodb:
-         uri: mongodb+srv://${MONGO_DBUSER}:${MONGO_DBPASS}@${MONGO_HOST}/${MONGO_DATABASE}${MONGO_OPTIONS}
+      uri: mongodb+srv://${MONGO_DBUSER}:${MONGO_DBPASS}@${MONGO_HOST}/${MONGO_DATABASE}${MONGO_OPTIONS}
 

--- a/src/main/resources/application-it.yml
+++ b/src/main/resources/application-it.yml
@@ -1,8 +1,7 @@
 spring:
-  data:
-    mongodb:
-      database: ${MONGO_DATABASE:madie}
-      uri: ${MONGO_URI:mongodb://gakins:E5press0@madie-terminology-mongo:27017/madie?authSource=admin&maxPoolSize=50&connectTimeoutMS=2000&serverSelectionTimeoutMS=2000}
+  mongodb:
+    database: ${MONGO_DATABASE:madie}
+    uri: ${MONGO_URI:mongodb://gakins:E5press0@madie-terminology-mongo:27017/madie?authSource=admin&maxPoolSize=50&connectTimeoutMS=2000&serverSelectionTimeoutMS=2000}
 
 
     

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,13 +47,15 @@ client:
     code-lookups: /CodeSystem/$lookup
 
 spring:
+  jackson:
+    deserialization:
+      fail-on-null-for-primitives: false
   session:
     store-type: none
   codec:
     max-in-memory-size: 24MB
-  data:
-    mongodb:
-      uri: ${MONGO_URI:mongodb://${DBUSER:root}:${DBPASS:E5press0}@localhost:27017/terminology}?authSource=admin&maxPoolSize=50&connectTimeoutMS=2000&serverSelectionTimeoutMS=2000
+  mongodb:
+    uri: ${MONGO_URI:mongodb://${DBUSER:root}:${DBPASS:E5press0}@localhost:27017/terminology}?authSource=admin&maxPoolSize=50&connectTimeoutMS=2000&serverSelectionTimeoutMS=2000
 
 mongock:
   migration-scan-package:

--- a/src/test/java/gov/cms/madie/terminology/config/migrations/LoadCodeSystemMappingDataTest.java
+++ b/src/test/java/gov/cms/madie/terminology/config/migrations/LoadCodeSystemMappingDataTest.java
@@ -1,7 +1,7 @@
 package gov.cms.madie.terminology.config.migrations;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import gov.cms.madie.models.mapping.CodeSystemEntry;
 import gov.cms.madie.terminology.models.CodeSystem;
 import gov.cms.madie.terminology.repositories.CodeSystemRepository;
@@ -64,7 +64,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithMatchingFhirAndVsacVersions() throws JsonProcessingException {
+  void testExistingCodeSystemWithMatchingFhirAndVsacVersions() throws JacksonException {
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
 
     when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
@@ -90,8 +90,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithMatchingFhirAndDifferingVsacVersions()
-      throws JsonProcessingException {
+  void testExistingCodeSystemWithMatchingFhirAndDifferingVsacVersions() throws JacksonException {
     mappingDocEntry.setVersions(
         List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").vsac("9.9.9").build()));
 
@@ -118,7 +117,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithMultipleVersions() throws JsonProcessingException {
+  void testExistingCodeSystemWithMultipleVersions() throws JacksonException {
     mappingDocEntry.setVersions(
         List.of(
             // Latest first
@@ -162,7 +161,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithOnlyVsacVersions() throws JsonProcessingException {
+  void testExistingCodeSystemWithOnlyVsacVersions() throws JacksonException {
     mappingDocEntry.setVersions(List.of(CodeSystemEntry.Version.builder().vsac("9.9.9").build()));
 
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
@@ -184,7 +183,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithOnlyFhirVersions() throws JsonProcessingException {
+  void testExistingCodeSystemWithOnlyFhirVersions() throws JacksonException {
     mappingDocEntry.setVersions(List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").build()));
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
 
@@ -207,7 +206,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testNewCodeSystemWithMatchingFhirAndVsacVersions() throws JsonProcessingException {
+  void testNewCodeSystemWithMatchingFhirAndVsacVersions() throws JacksonException {
     mappingDocEntry.setVersions(
         List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").vsac("1.0.0").build()));
     when(codeSystemRepositoryMock.findAll()).thenReturn(Collections.emptyList());
@@ -234,7 +233,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testNewCodeSystemWithDifferingFhirAndVsacVersions() throws JsonProcessingException {
+  void testNewCodeSystemWithDifferingFhirAndVsacVersions() throws JacksonException {
     mappingDocEntry.setVersions(
         List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").vsac("9.9.9").build()));
 
@@ -263,7 +262,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testNewCodeSystemWithOnlyVsacVersions() throws JsonProcessingException {
+  void testNewCodeSystemWithOnlyVsacVersions() throws JacksonException {
     mappingDocEntry.setVersions(List.of(CodeSystemEntry.Version.builder().vsac("9.9.9").build()));
 
     when(codeSystemRepositoryMock.findAll()).thenReturn(Collections.emptyList());
@@ -291,7 +290,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testNewCodeSystemWithOnlyFhirVersions() throws JsonProcessingException {
+  void testNewCodeSystemWithOnlyFhirVersions() throws JacksonException {
     mappingDocEntry.setVersions(List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").build()));
     mappingDocEntry.setOid("NOT.IN.VSAC.TEST");
     when(codeSystemRepositoryMock.findAll()).thenReturn(Collections.emptyList());
@@ -317,7 +316,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testRollbackUsesOriginalCodeSystems() throws JsonProcessingException {
+  void testRollbackUsesOriginalCodeSystems() throws JacksonException {
     when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
         .thenReturn(new CodeSystemEntry[] {mappingDocEntry});
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
@@ -342,9 +341,9 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testRollbackDoesNothingIfMappingDocFailsParsing() throws JsonProcessingException {
+  void testRollbackDoesNothingIfMappingDocFailsParsing() throws JacksonException {
     when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
-        .thenThrow(new JsonProcessingException("Test Exception") {});
+        .thenThrow(new JacksonException("Test Exception") {});
     assertThrows(
         RuntimeException.class,
         () ->

--- a/src/test/java/gov/cms/madie/terminology/config/migrations/LoadCodeSystemMappingDataTest.java
+++ b/src/test/java/gov/cms/madie/terminology/config/migrations/LoadCodeSystemMappingDataTest.java
@@ -64,7 +64,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithMatchingFhirAndVsacVersions() throws JacksonException {
+  void testExistingCodeSystemWithMatchingFhirAndVsacVersions() {
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
 
     when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
@@ -90,7 +90,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithMatchingFhirAndDifferingVsacVersions() throws JacksonException {
+  void testExistingCodeSystemWithMatchingFhirAndDifferingVsacVersions() {
     mappingDocEntry.setVersions(
         List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").vsac("9.9.9").build()));
 
@@ -117,7 +117,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithMultipleVersions() throws JacksonException {
+  void testExistingCodeSystemWithMultipleVersions() {
     mappingDocEntry.setVersions(
         List.of(
             // Latest first
@@ -161,7 +161,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithOnlyVsacVersions() throws JacksonException {
+  void testExistingCodeSystemWithOnlyVsacVersions() {
     mappingDocEntry.setVersions(List.of(CodeSystemEntry.Version.builder().vsac("9.9.9").build()));
 
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
@@ -183,7 +183,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testExistingCodeSystemWithOnlyFhirVersions() throws JacksonException {
+  void testExistingCodeSystemWithOnlyFhirVersions() {
     mappingDocEntry.setVersions(List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").build()));
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
 
@@ -206,7 +206,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testNewCodeSystemWithMatchingFhirAndVsacVersions() throws JacksonException {
+  void testNewCodeSystemWithMatchingFhirAndVsacVersions() {
     mappingDocEntry.setVersions(
         List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").vsac("1.0.0").build()));
     when(codeSystemRepositoryMock.findAll()).thenReturn(Collections.emptyList());
@@ -233,7 +233,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testNewCodeSystemWithDifferingFhirAndVsacVersions() throws JacksonException {
+  void testNewCodeSystemWithDifferingFhirAndVsacVersions() {
     mappingDocEntry.setVersions(
         List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").vsac("9.9.9").build()));
 
@@ -262,7 +262,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testNewCodeSystemWithOnlyVsacVersions() throws JacksonException {
+  void testNewCodeSystemWithOnlyVsacVersions() {
     mappingDocEntry.setVersions(List.of(CodeSystemEntry.Version.builder().vsac("9.9.9").build()));
 
     when(codeSystemRepositoryMock.findAll()).thenReturn(Collections.emptyList());
@@ -290,7 +290,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testNewCodeSystemWithOnlyFhirVersions() throws JacksonException {
+  void testNewCodeSystemWithOnlyFhirVersions() {
     mappingDocEntry.setVersions(List.of(CodeSystemEntry.Version.builder().fhir("1.0.0").build()));
     mappingDocEntry.setOid("NOT.IN.VSAC.TEST");
     when(codeSystemRepositoryMock.findAll()).thenReturn(Collections.emptyList());
@@ -316,7 +316,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testRollbackUsesOriginalCodeSystems() throws JacksonException {
+  void testRollbackUsesOriginalCodeSystems() {
     when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
         .thenReturn(new CodeSystemEntry[] {mappingDocEntry});
     when(codeSystemRepositoryMock.findAll()).thenReturn(List.of(existingCodeSystem));
@@ -341,7 +341,7 @@ class LoadCodeSystemMappingDataTest {
   }
 
   @Test
-  void testRollbackDoesNothingIfMappingDocFailsParsing() throws JacksonException {
+  void testRollbackDoesNothingIfMappingDocFailsParsing() {
     when(objectMapperMock.readValue(anyString(), eq(CodeSystemEntry[].class)))
         .thenThrow(new JacksonException("Test Exception") {});
     assertThrows(

--- a/src/test/java/gov/cms/madie/terminology/controller/AdminControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/terminology/controller/AdminControllerMvcTest.java
@@ -1,7 +1,7 @@
 package gov.cms.madie.terminology.controller;
 
 import ca.uhn.fhir.context.FhirContext;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import gov.cms.madie.terminology.clients.UserServiceClient;
 import gov.cms.madie.terminology.config.SecurityConfig;
 import gov.cms.madie.terminology.models.UmlsUser;
@@ -13,7 +13,7 @@ import gov.cms.madie.terminology.service.FhirTerminologyService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;

--- a/src/test/java/gov/cms/madie/terminology/controller/ValueSetExpansionControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/terminology/controller/ValueSetExpansionControllerMvcTest.java
@@ -6,7 +6,7 @@ import ca.uhn.fhir.context.FhirContext;
 import gov.cms.madie.terminology.service.ValueSetExpansionService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;

--- a/src/test/java/gov/cms/madie/terminology/controller/VsacControllerAdviceTest.java
+++ b/src/test/java/gov/cms/madie/terminology/controller/VsacControllerAdviceTest.java
@@ -6,7 +6,7 @@ import org.hl7.fhir.r4.model.OperationOutcome;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.boot.webmvc.error.ErrorAttributes;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -19,7 +19,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-class StubErrorAttributes implements org.springframework.boot.web.servlet.error.ErrorAttributes {
+class StubErrorAttributes implements org.springframework.boot.webmvc.error.ErrorAttributes {
   @Override
   public Map<String, Object> getErrorAttributes(
       WebRequest webRequest, org.springframework.boot.web.error.ErrorAttributeOptions options) {

--- a/src/test/java/gov/cms/madie/terminology/controller/VsacFhirTerminologyControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/terminology/controller/VsacFhirTerminologyControllerMvcTest.java
@@ -13,12 +13,15 @@ import gov.cms.madie.terminology.service.VsacService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import gov.cms.madie.terminology.config.SecurityConfig;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.security.Principal;
@@ -28,7 +31,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -39,6 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(VsacFhirTerminologyController.class)
 @ActiveProfiles("test")
+@Import(SecurityConfig.class)
 class VsacFhirTerminologyControllerMvcTest {
 
   private static final String TEST_USR = "FAKE";
@@ -169,7 +173,7 @@ class VsacFhirTerminologyControllerMvcTest {
         """
     		[{"oid":"test-value-set-id-1234","display_name":"test-value-set-display-name","version":"20240101","concepts":[{"code":"test-code-052","code_system_oid":null,"code_system_name":null,"code_system_version":null,"display_name":null}]}]
     		""";
-    assertEquals(content, valueSetExpansion.trim());
+    assertEquals(valueSetExpansion.trim(), content, JSONCompareMode.STRICT);
   }
 
   @Test

--- a/src/test/java/gov/cms/madie/terminology/util/ImplementationGuideManagerTest.java
+++ b/src/test/java/gov/cms/madie/terminology/util/ImplementationGuideManagerTest.java
@@ -408,7 +408,7 @@ class ImplementationGuideManagerTest {
 
     try (MockedStatic<ImplementationGuideLoader> loader =
         mockStatic(ImplementationGuideLoader.class)) {
-      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig));
+      loader.when(() -> ImplementationGuideLoader.load(anyString())).thenReturn(List.of(ig));
       loader
           .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), any()))
           .thenReturn(mockPm);
@@ -418,7 +418,7 @@ class ImplementationGuideManagerTest {
       List<MadieValueSet> result = manager.getValueSetDependencies("hl7.fhir.us.core", "6.1.0");
 
       assertFalse(result.isEmpty());
-      loader.verify(ImplementationGuideLoader::load, times(1));
+      loader.verify(() -> ImplementationGuideLoader.load(anyString()), times(1));
     }
   }
 
@@ -440,7 +440,7 @@ class ImplementationGuideManagerTest {
 
     try (MockedStatic<ImplementationGuideLoader> loader =
         mockStatic(ImplementationGuideLoader.class)) {
-      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig));
+      loader.when(() -> ImplementationGuideLoader.load(anyString())).thenReturn(List.of(ig));
       loader
           .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), any()))
           .thenReturn(mockPm);
@@ -478,7 +478,7 @@ class ImplementationGuideManagerTest {
 
     try (MockedStatic<ImplementationGuideLoader> loader =
         mockStatic(ImplementationGuideLoader.class)) {
-      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig));
+      loader.when(() -> ImplementationGuideLoader.load(anyString())).thenReturn(List.of(ig));
       loader
           .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), any()))
           .thenReturn(mockPm);
@@ -504,7 +504,7 @@ class ImplementationGuideManagerTest {
 
     try (MockedStatic<ImplementationGuideLoader> loader =
         mockStatic(ImplementationGuideLoader.class)) {
-      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig));
+      loader.when(() -> ImplementationGuideLoader.load(anyString())).thenReturn(List.of(ig));
       loader
           .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), any()))
           .thenReturn(mockPm);
@@ -548,7 +548,7 @@ class ImplementationGuideManagerTest {
 
     try (MockedStatic<ImplementationGuideLoader> loader =
         mockStatic(ImplementationGuideLoader.class)) {
-      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig1, ig2));
+      loader.when(() -> ImplementationGuideLoader.load(anyString())).thenReturn(List.of(ig1, ig2));
       loader
           .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), eq(ig1)))
           .thenReturn(pm1);
@@ -567,7 +567,9 @@ class ImplementationGuideManagerTest {
   void getValueSetDependenciesReturnsEmptyListWhenNoIgsLoaded() {
     try (MockedStatic<ImplementationGuideLoader> loader =
         mockStatic(ImplementationGuideLoader.class)) {
-      loader.when(ImplementationGuideLoader::load).thenReturn(Collections.emptyList());
+      loader
+          .when(() -> ImplementationGuideLoader.load(anyString()))
+          .thenReturn(Collections.emptyList());
 
       List<MadieValueSet> result = manager.getValueSetDependencies();
 
@@ -626,7 +628,7 @@ class ImplementationGuideManagerTest {
 
     try (MockedStatic<ImplementationGuideLoader> loader =
         mockStatic(ImplementationGuideLoader.class)) {
-      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig));
+      loader.when(() -> ImplementationGuideLoader.load(anyString())).thenReturn(List.of(ig));
       loader
           .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), any()))
           .thenReturn(mockPm);
@@ -653,7 +655,7 @@ class ImplementationGuideManagerTest {
         mockStatic(ImplementationGuideLoader.class)) {
       // load() succeeds but buildPackageManager throws, leaving state in ERROR-ish state
       ImplementationGuide ig = buildTestIg("failing-ig", "1.0.0");
-      loader.when(ImplementationGuideLoader::load).thenReturn(List.of(ig));
+      loader.when(() -> ImplementationGuideLoader.load(anyString())).thenReturn(List.of(ig));
       loader
           .when(() -> ImplementationGuideLoader.buildPackageManager(isNull(), any()))
           .thenThrow(new IOException("network failure"));


### PR DESCRIPTION
## Terminology Service PR

Jira Ticket: [MAT-10059](https://jira.cms.gov/browse/MAT-10059)
(Optional) Related Tickets:

### Summary

# Spring Boot 4 + Jackson 3 Upgrade Notes — terminology-service

Part of the fleet-wide SB 3.5.14 → 4.0.6 + Jackson 2 → 3 migration. Common patterns live in
`madie-fhir-service/SPRING_BOOT_4_UPGRADE.md`; this file records only what was specific to this repo.
This service uses both WebMvc and reactive `WebClient`, MongoDB, and `translator-commons` — so it hit the
widest set of SB4 issues of any service so far.

## pom.xml
- Parent `3.5.14` → `4.0.6`; **`java.version` `16` → `17`** (SB4 minimum). okta property `3.0.7` → `3.1.0`.
- `madie-java-models` `0.8.9-SNAPSHOT` → `0.10.0-SNAPSHOT`; `madie-translator-commons` `3.1.1` → `3.5.0`
  (this service does **not** use `CqlLibraryService`, so no `FhirUtil` @Import coupling — but it *does*
  use `ImplementationGuideLoader`, see below).
- `spring-boot-starter-web` → `spring-boot-starter-webmvc`; added oauth2-resource-server/client,
  `spring-boot-restclient`, `spring-boot-webmvc-test` (test).
- **Added `spring-boot-starter-webclient`** — the reactive `WebClient.Builder` is no longer auto-configured
  by `spring-boot-starter-webflux` alone in SB4; without this the context fails with
  `No qualifying bean WebClient$Builder`.

## Source — Spring 7 / web
- **`WebClient` status checks:** `clientResponse.statusCode().equals(HttpStatus.X)` silently returns
  `false` in Spring 7 (`statusCode()` returns an `HttpStatusCode` that no longer `.equals` the `HttpStatus`
  enum) → the 422/404 branches never ran. Replaced all with `statusCode().isSameCodeAs(HttpStatus.X)`.
- **`WebClientResponseException.getRawStatusCode()` removed** → `getStatusCode().value()`.
- `UserServiceClientConfig`: removed Jackson-2 converter surgery → `builder.additionalInterceptors(...).build()`;
  `RestTemplateBuilder` import → `org.springframework.boot.restclient`.
- `UriComponentsBuilder.fromHttpUrl(...)` → `fromUriString(...)`.
- `ErrorAttributes` → `org.springframework.boot.webmvc.error` (main `VsacControllerAdvice` + its test).
- `ImplementationGuideLoader.load()` → `load("classpath*:igs/*.json")` (MAT-10029 API change baked into
  translator-commons 3.5.0; the no-arg `load()` was removed); the test's `ImplementationGuideLoader::load`
  method-ref → `() -> ...load(anyString())`. **The literal `"classpath*:igs/*.json"` is exactly the glob the old
  no-arg `load()` used internally (`IG_CLASSPATH_PATTERN`), so the IGs loaded are unchanged — behavior-preserving.**
  Note the **intentional divergence** from fhir-elm-translator, the other consumer, which adopted MAT-10029's full
  idiom (`@Value("${madie.ig-resource-pattern:classpath*:igs/*.json}")`): terminology keeps the hardcoded literal
  because its tests mock `load` statically (no need for the test-override property the parameter was added for).
  Same runtime glob either way; the difference is not an oversight.
- Jackson: `ObjectMapper` → `tools.jackson.databind`; `JsonProcessingException` → `tools.jackson.core.JacksonException`;
  a now-unreachable `catch (IOException)` around `readValue` → `catch (JacksonException)`.

## ⚠️ Jackson 3 deserialization strictness (recurs fleet-wide)
- **`@Builder` model classes without `@NoArgsConstructor` fail to deserialize** under Jackson 3
  (`InvalidDefinitionException: no Creators ... no default constructor`). Jackson 2 was lenient about using
  the all-args/builder constructor; Jackson 3 isn't. Fixed `CodeSystem.Version` and
  `ValueSetsSearchCriteria` (+ inner `ValueSetParams`) by adding `@AllArgsConstructor` + `@NoArgsConstructor`
  to match their outer classes' pattern.

## ⚠️ Jackson 3 default property ORDER changed (recurs in exact-JSON tests)
- Jackson 3 serializes object properties **alphabetically by default**; Jackson 2 used declaration order.
  This breaks tests that compare the response as an **exact JSON string** (the data is identical, only field
  order differs). **Do NOT fix this by adding `@JsonPropertyOrder` to production DTOs** to satisfy a test —
  the brittleness is in the test. Fixed `VsacFhirTerminologyControllerMvcTest` by switching its one exact
  `assertEquals(content, expected)` to **`JSONAssert.assertEquals(expected, content, JSONCompareMode.STRICT)`**
  (order-insensitive on object keys, still catches missing/extra fields and array order). `jsonassert` is on
  the classpath via `spring-boot-starter-test`.

## Tests
- Relocated `org.springframework.boot.test.autoconfigure.web.servlet.*` → `…webmvc.test.autoconfigure.*`.
- `@WebMvcTest` slices that don't import a SecurityConfig fail context load (oauth2 autoconfig needs
  `HttpSecurity`) → added `@Import(SecurityConfig.class)` (Pattern A) to `VsacFhirTerminologyControllerMvcTest`
  (AdminControllerMvcTest already imported it).

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
